### PR TITLE
XEB: Brought small cosmetic adjustments to script

### DIFF
--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/gateset.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/gateset.py
@@ -113,9 +113,9 @@ def generate_gate_set(gate_set: Literal["sw", "t"], baseline_gate_name: str) -> 
     """
 
     sx_gate = QUAGate("sx", play_sq_gate_macro(baseline_gate_name), amp_matrix=[1.0, 0.0, 0.0, 1.0])
-    SY = RYGate(np.pi / 2).to_matrix()
+    sy = RYGate(np.pi / 2).to_matrix()
     sy_gate = QUAGate(
-        ("sy", SY),
+        ("sy", sy),
         play_sq_gate_macro(baseline_gate_name, [0.0, -1.0, 1.0, 0.0]),
         amp_matrix=[0.0, -1.0, 1.0, 0.0],
     )

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/macros.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/macros.py
@@ -10,7 +10,7 @@ from qiskit.transpiler import CouplingMap
 from qm.qua import *
 from qualang_tools.addons.variables import assign_variables_to_element
 import numpy as np
-from quam.examples.superconducting_qubits import Transmon
+from quam_libs.components import TransmonPair, Transmon
 from scipy import optimize
 from scipy.stats import stats
 from itertools import combinations
@@ -113,6 +113,25 @@ def active_reset(threshold: float, qubit: Transmon, max_tries=1, Ig=None, pi_pul
         # Increment the number of tries
         assign(counter, counter + 1)
     return Ig, counter
+
+
+def align_transmon(qubit: Transmon):
+    """
+    Macro to align all qubit drives with the associated resonator
+    """
+    qubit.xy.align(qubit.resonator.name, qubit.z.name)
+
+
+def align_transmon_pair(qubit_pair: TransmonPair):
+    """
+    Macro to align all qubit drives with the associated resonators for a given qubit pair
+    """
+    all_channels = ["xy", "z", "resonator"]
+    all_elements = []
+    for qubit in [qubit_pair.qubit_control, qubit_pair.qubit_target]:
+        for channel in all_channels:
+            all_elements.append(getattr(qubit, channel).name)
+    align(*all_elements)
 
 
 def get_parallel_gate_combinations(coupling_map: CouplingMap, direction="forward"):


### PR DESCRIPTION
The saving of amplitude matrices has been improved such that we can now really recover actual matrices.

Furthermore, an additional macro to align qubit pair is defined to ease readability in code.

On the post processing side, warning will be raised instead of errors when a line of plot is not available due to lack of data (e.g. if log XEB did yield only nan but not linear XEB).
