### PR TITLE
Added XEBResult_from data method and corrected bug for multi qubit XEB with CZ

### DIFF
--- a/Quantum-Control-Applications-QuAM/Superconducting/calibrations/26_two_qubit_xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibrations/26_two_qubit_xeb.py
@@ -59,7 +59,7 @@ xeb_config = XEBConfig(
 simulate = False  # Set to True to simulate the experiment with Qiskit Aer instead of running it on the QPU
 hardware_simulate = True
 
-xeb = XEB(xeb_config, quam=machine)
+xeb = XEB(xeb_config, machine=machine)
 if simulate:
     job = xeb.simulate(backend=fake_backend)
 else:

--- a/Quantum-Control-Applications-QuAM/Superconducting/pyproject.toml
+++ b/Quantum-Control-Applications-QuAM/Superconducting/pyproject.toml
@@ -21,7 +21,7 @@ lmfit = "*"
 qiskit-experiments = "*"
 tqdm = "*"
 qualibrate = "*"
-qm-qua = "1.2.1"
+qm-qua = "1.2.1a2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/__init__.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/__init__.py
@@ -1,5 +1,5 @@
 from .xeb_config import XEBConfig
 from .qua_gate import QUAGate
 from .gateset import QUAGateSet
-from .xeb import XEB
+from .xeb import XEB, XEBResult
 from .simulated_backend import backend

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/simulated_backend.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/simulated_backend.py
@@ -4,11 +4,11 @@ from qiskit.transpiler import CouplingMap
 
 num_qubits = 5
 cm = CouplingMap.from_line(num_qubits, False)
-error1q = 0.02  # single qubit gate error rate
+error1q = 0.01  # single qubit gate error rate
 error2q = 0.05  # two qubit gate error rate
 depol_error1q = depolarizing_error(error1q, 1)
 depol_error2q = depolarizing_error(error2q, 2)
-sq_gate_set = ["h", "t", "sx", "ry"]#, "sw"]
+sq_gate_set = ["h", "t", "sx", "ry", "sw"]
 noise_model = NoiseModel(basis_gates=sq_gate_set)
 if num_qubits == 2:
     noise_model.add_all_qubit_quantum_error(depol_error2q, ["cz", "cx"])
@@ -18,5 +18,4 @@ backend = AerSimulator(
     coupling_map=cm,
     noise_model=noise_model,
     method="density_matrix",
-    basis_gates=noise_model.basis_gates,
 )

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -765,7 +765,9 @@ class XEBResult:
         depths = self.xeb_config.depths
         counts = self.counts
         states = self.states
-        if "joint_expected_probs" not in self.data.keys():
+        
+        existing_data = 'joint_expected_probs' in self.data.keys()
+        if existing_data:
             expected_probs = np.zeros((seqs, len(depths), dim))
             disjoint_expected_probs = np.zeros((n_qubits, seqs, len(depths), dim))
         else:
@@ -788,7 +790,7 @@ class XEBResult:
         for s in range(seqs):
             for d_, d in enumerate(depths):
                 qc = self.circuits[s][d_].remove_final_measurements(inplace=False)
-                if "joint_expected_probs" not in self.data.keys():
+                if existing_data:
                     statevector = Statevector(qc)
                     expected_probs[s, d_] = np.round(statevector.probabilities(), 5)
                     for q in range(n_qubits):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -641,10 +641,13 @@ class XEBJob:
         gate_sequences = np.zeros(
             (self.xeb_config.seqs, self.xeb_config.n_qubits, self.xeb_config.depths[-1]), dtype=str
         )
-        for s in range(self.xeb_config.seqs):
-            for q in range(self.xeb_config.n_qubits):
-                for d in range(self.xeb_config.depths[-1]):
-                    gate_sequences[s, q, d] = self.xeb_config.gate_set[self._gate_indices[s, q, d]].name
+        if self.gate_indices:
+            for s in range(self.xeb_config.seqs):
+                for q in range(self.xeb_config.n_qubits):
+                    for d in range(self.xeb_config.depths[-1]):
+                        gate_sequences[s, q, d] = self.xeb_config.gate_set[self.gate_indices[s, q, d]].name
+        else:
+            raise ValueError("No gate indices found. Run the experiment to retrieve the gate sequences.")
         return gate_sequences
 
     def plot_simulated_samples(self):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -751,7 +751,10 @@ class XEBResult:
                 qc = self.circuits[s][d_].remove_final_measurements(inplace=False)
 
                 if not self.xeb_config.disjoint_processing:
-                    expected_probs[s, d_] = np.round(Statevector(qc).probabilities(), 5)
+                    if "expected_probs" in self.saved_data.keys():
+                        expected_probs[s, d_] = self.saved_data["expected_probs"][s][d_]
+                    else:
+                        expected_probs[s, d_] = np.round(Statevector(qc).probabilities(), 5)
                     measured_probs[s, d_] = (
                         np.array([counts[binary(i, n_qubits)][s][d_] for i in range(dim)]) / self.xeb_config.n_shots
                     )
@@ -783,7 +786,10 @@ class XEBResult:
 
                 else:
                     for q in range(n_qubits):
-                        expected_probs[q, s, d_] = np.round(Statevector(qc).probabilities([q]), 5)
+                        if "expected_probs" in self.saved_data.keys():
+                            expected_probs[q, s, d_] = self.saved_data["expected_probs"][q][s][d_]
+                        else:
+                            expected_probs[q, s, d_] = np.round(Statevector(qc).probabilities([q]), 5)
                         measured_probs[q, s, d_] = np.array(
                             [1 - states[f"state{q}"][s][d_], states[f"state{q}"][s][d_]]
                         )

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -892,6 +892,7 @@ class XEBResult:
 
         if self.xeb_config.disjoint_processing:
             for q, qubit in enumerate(self.qubit_names):
+                plt.figure()
                 linear_fidelities = self.linear_fidelities[q]
                 xx = np.linspace(0, linear_fidelities["depth"].max())
                 try:  # Fit the data for the linear XEB

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -896,6 +896,12 @@ class XEBResult:
             for q, qubit in enumerate(self.qubit_names):
                 if separate_plots:
                     plt.figure()
+                    plt.ylabel("Circuit fidelity", fontsize=20)
+                    plt.xlabel("Cycle Depth $d$", fontsize=20)
+                    plt.title("XEB Fidelity")
+                    plt.legend(loc="best")
+                    plt.tight_layout()
+                    plt.show()
                 linear_fidelities = self.linear_fidelities[q]
                 xx = np.linspace(0, linear_fidelities["depth"].max())
                 try:  # Fit the data for the linear XEB
@@ -998,12 +1004,12 @@ class XEBResult:
             else:
                 warnings.warn("Log XEB data does not contain any physical values.")
 
-        plt.ylabel("Circuit fidelity", fontsize=20)
-        plt.xlabel("Cycle Depth $d$", fontsize=20)
-        plt.title("XEB Fidelity")
-        plt.legend(loc="best")
-        plt.tight_layout()
-        plt.show()
+            plt.ylabel("Circuit fidelity", fontsize=20)
+            plt.xlabel("Cycle Depth $d$", fontsize=20)
+            plt.title("XEB Fidelity")
+            plt.legend(loc="best")
+            plt.tight_layout()
+            plt.show()
 
     def plot_records(self):
         """

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -641,13 +641,11 @@ class XEBJob:
         gate_sequences = np.zeros(
             (self.xeb_config.seqs, self.xeb_config.n_qubits, self.xeb_config.depths[-1]), dtype=str
         )
-        if self.gate_indices:
-            for s in range(self.xeb_config.seqs):
-                for q in range(self.xeb_config.n_qubits):
-                    for d in range(self.xeb_config.depths[-1]):
-                        gate_sequences[s, q, d] = self.xeb_config.gate_set[self.gate_indices[s, q, d]].name
-        else:
-            raise ValueError("No gate indices found. Run the experiment to retrieve the gate sequences.")
+        for s in range(self.xeb_config.seqs):
+            for q in range(self.xeb_config.n_qubits):
+                for d in range(self.xeb_config.depths[-1]):
+                    gate_sequences[s, q, d] = self.xeb_config.gate_set[self.gate_indices[s, q, d]].name
+      
         return gate_sequences
 
     def plot_simulated_samples(self):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -543,7 +543,7 @@ class XEBJob:
         Returns: XEBResult object containing the results of the experiment
 
         """
-        
+
         if disjoint_processing is not None:
             assert isinstance(disjoint_processing, bool), "disjoint_processing should be a boolean"
             self.xeb_config.disjoint_processing = disjoint_processing
@@ -741,7 +741,7 @@ class XEBResult:
             else:
                 new_data[key] = value
 
-        return cls(xeb_config, circuits, new_data["counts"], new_data["states"], new_data , data_handler)
+        return cls(xeb_config, circuits, new_data["counts"], new_data["states"], new_data, data_handler)
 
     def retrieve_data(self):
         """

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -686,12 +686,13 @@ class XEBResult:
                 "measured_probs": self._measured_probs,
                 "expected_probs": self._expected_probs,
                 "log_fidelities": self._log_fidelities,
-                "linear_fidelities": self._linear_fidelities,
+                "linear_fidelities": self.linear_fidelities,
                 "singularities": np.array(self._singularities),
             }
         )
         if self.xeb_config.should_save_data and self.data_handler is not None:
-            self.data_handler.save_data(self.data, self.xeb_config.data_folder_name, metadata=self.xeb_config.as_dict())
+            self.data_handler.save_data(self.data, self.xeb_config.data_folder_name,
+                                        metadata=self.xeb_config.as_dict())
 
     @classmethod
     def from_data(
@@ -772,7 +773,7 @@ class XEBResult:
 
                 if not self.xeb_config.disjoint_processing:
                     if "expected_probs" in self.data.keys():
-                        expected_probs[s, d_] = self.data["expected_probs"][s][d_]
+                        expected_probs[s, d_] = self.data["expected_probs"][s, d_]
                     else:
                         expected_probs[s, d_] = np.round(Statevector(qc).probabilities(), 5)
                     measured_probs[s, d_] = (
@@ -1165,7 +1166,11 @@ class XEBResult:
         Linear fidelities
         Returns: Linear fidelities
         """
-        return self._linear_fidelities
+        if self.xeb_config.disjoint_processing:
+            fidelities = [self._linear_fidelities[q]["fidelity"] for q in range(self.xeb_config.n_qubits)]
+        else:
+            fidelities = self._linear_fidelities["fidelity"]
+        return  fidelities
 
     @property
     def singularities(self):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -712,7 +712,7 @@ class XEBResult:
         if disjoint_processing is not None:
             assert isinstance(disjoint_processing, bool), "disjoint_processing should be a boolean"
             xeb_config.disjoint_processing = disjoint_processing
-        gate_indices = np.load(arrays["gate_indices"])
+        gate_indices = arrays["gate_indices"]
         circuits = generate_circuits(xeb_config, gate_indices, xeb_config.available_combinations)
 
         new_data = {"states": {}, "counts": {}, "quadratures": {}, "amp_st": {}}

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -740,7 +740,7 @@ class XEBResult:
             else:
                 new_data[key] = value
 
-        return cls(xeb_config, circuits, new_data, new_data["counts"], new_data["states"], data_handler)
+        return cls(xeb_config, circuits, new_data["counts"], new_data["states"], new_data , data_handler)
 
     def retrieve_data(self):
         """

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -208,9 +208,9 @@ class XEB:
             r.set_seed(12321)
 
             # If simulating, update the frequency to 0 to visualize sequence
-            # if simulate:
-                # for qubit in self.qubit_drive_channels:
-                #     update_frequency(qubit.name, 0)
+            if simulate:
+                for qubit in self.qubit_drive_channels:
+                    update_frequency(qubit.name, 0)
 
             # Generate the random sequences
             with for_(s, 0, s < self.xeb_config.seqs, s + 1):
@@ -374,7 +374,7 @@ class XEB:
         config = self.machine.generate_config()
         if simulation_config is None:
             simulation_config = SimulationConfig(duration=10_000)
-        xeb_prog = self._xeb_prog(simulate=True)  # set simulate=True to get the amplitude matrix
+        xeb_prog = self._xeb_prog(simulate=simulate)  # set simulate=True to get the amplitude matrix
         if simulate and qmm_cloud_simulator is not None:
             qmm = qmm_cloud_simulator
         else:

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -788,10 +788,14 @@ class XEBResult:
                 if "joint_expected_probs" not in self.data.keys():
                     statevector = Statevector(qc)
                     expected_probs[s, d_] = np.round(statevector.probabilities(), 5)
-                    disjoint_expected_probs[:, s, d_] = np.round(statevector.probabilities(), 5)
+                    for q in range(n_qubits):
+                        disjoint_expected_probs[q, s, d_] = np.round(
+                            statevector.probabilities([q]), 5
+                        )
                 else:
                     expected_probs[s, d_] = self.data["joint_expected_probs"][s, d_]
-                    disjoint_expected_probs[:, s, d_] = self.data["disjoint_expected_probs"][s, d_]
+                    for q in range(n_qubits):
+                        disjoint_expected_probs[q, s, d_] = self.data["disjoint_expected_probs"][q, s, d_]
 
                 if not self.xeb_config.disjoint_processing:
                     measured_probs[s, d_] = (

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -521,12 +521,18 @@ class XEBJob:
             circuits = generate_circuits(self.xeb_config, self.gate_indices)
         return circuits
 
-    def result(self):
+    def result(self, disjoint_processing: Optional[bool] = None):
         """
         Returns the results of the XEB experiment
+        
+        Args:
+            disjoint_processing: Indicate if disjoint processing should be applied to the results
         Returns: XEBResult object containing the results of the experiment
 
         """
+        if disjoint_processing is not None:
+            assert isinstance(disjoint_processing, bool), "disjoint_processing should be a boolean"
+            self.xeb_config.disjoint_processing = disjoint_processing
         if self._simulate:
             result = self.job.result()
             counts = result.get_counts()

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -543,6 +543,7 @@ class XEBJob:
         Returns: XEBResult object containing the results of the experiment
 
         """
+        
         if disjoint_processing is not None:
             assert isinstance(disjoint_processing, bool), "disjoint_processing should be a boolean"
             self.xeb_config.disjoint_processing = disjoint_processing
@@ -554,12 +555,12 @@ class XEBJob:
                 for key in [binary(i, self.xeb_config.n_qubits) for i in range(self.xeb_config.dim)]:
                     if key not in count.keys():
                         count[key] = 0
-            states = [{f"state_{q}": 0.0 for q in range(self.xeb_config.n_qubits)} for _ in range(len(counts))]
+            states = [{f"state_{qubit.name}": 0.0 for qubit in self.xeb_config.qubits} for _ in range(len(counts))]
             for c, count in enumerate(counts):
                 for key, value in count.items():
                     for i, bit in enumerate(reversed(key)):
                         if bit == "1":
-                            states[c][f"state_{i}"] += value
+                            states[c][f"state_{self.xeb_config.qubits[i].name}"] += value
             states = {
                 key: np.reshape(
                     [state[key] / self.xeb_config.n_shots for state in states],

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -767,7 +767,7 @@ class XEBResult:
         states = self.states
         
         existing_data = 'joint_expected_probs' in self.data.keys()
-        if existing_data:
+        if not existing_data:
             expected_probs = np.zeros((seqs, len(depths), dim))
             disjoint_expected_probs = np.zeros((n_qubits, seqs, len(depths), dim))
         else:
@@ -790,7 +790,7 @@ class XEBResult:
         for s in range(seqs):
             for d_, d in enumerate(depths):
                 qc = self.circuits[s][d_].remove_final_measurements(inplace=False)
-                if existing_data:
+                if not existing_data:
                     statevector = Statevector(qc)
                     expected_probs[s, d_] = np.round(statevector.probabilities(), 5)
                     for q in range(n_qubits):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -739,7 +739,7 @@ class XEBResult:
             elif key.startswith("I") or key.startswith("Q"):
                 new_data["quadratures"][key] = arrays[key]
             else:
-                new_data[key] = value
+                new_data[key] = arrays[key]
 
         return cls(xeb_config, circuits, new_data["counts"], new_data["states"], new_data, data_handler)
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -706,25 +706,26 @@ class XEBResult:
             data_handler: DataHandler object to handle the data
         """
         data: Dict = json.load(open(directory + "/data.json", "r"))
+        arrays:Dict = np.load(directory + "/arrays.npz")
         metadata: Dict = json.load(open(directory + "/node.json", "r"))
         xeb_config = XEBConfig.from_dict(metadata["metadata"])
         if disjoint_processing is not None:
             assert isinstance(disjoint_processing, bool), "disjoint_processing should be a boolean"
             xeb_config.disjoint_processing = disjoint_processing
-        gate_indices = np.load(data["gate_indices"])
+        gate_indices = np.load(arrays["gate_indices"])
         circuits = generate_circuits(xeb_config, gate_indices, xeb_config.available_combinations)
 
         new_data = {"states": {}, "counts": {}, "quadratures": {}, "amp_st": {}}
 
         for key, value in data.items():
             if "state" in key:
-                new_data["states"][key] = np.load(value)
+                new_data["states"][key] = arrays[key]
             elif key.isnumeric():
-                new_data["counts"][key] = np.load(value)
+                new_data["counts"][key] = arrays[key]
             elif "amp_matrix" in key:
-                new_data["amp_st"][key] = np.load(value)
-            elif "I" in key or "Q" in key:
-                new_data["quadratures"][key] = np.load(value)
+                new_data["amp_st"][key] = arrays[key]
+            elif key.startswith("I") or key.startswith("Q"):
+                new_data["quadratures"][key] = arrays[key]
             else:
                 new_data[key] = value
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -692,22 +692,22 @@ class XEBResult:
             data_handler: DataHandler object to handle the data
         """
         data: Dict = json.load(open(saved_data_file, "r"))
-        gate_indices = data["gate_indices"]
+        gate_indices = np.load(data["gate_indices"])
         circuits = generate_circuits(xeb_config, gate_indices)
 
         new_data = {"states": {}, "counts": {}, "quadratures": {}, "amp_st": {}}
 
         for key, value in data.items():
             if "state" in key:
-                new_data["states"][key] = value
+                new_data["states"][key] = np.load(value)
             elif key.isnumeric():
-                new_data["counts"][key] = value
+                new_data["counts"][key] = np.load(value)
             elif "amp_matrix" in key:
-                new_data["amp_st"][key] = value
+                new_data["amp_st"][key] = np.load(value)
             elif "I" in key or "Q" in key:
-                new_data["quadratures"][key] = value
+                new_data["quadratures"][key] = np.load(value)
             else:
-                new_data[key] = value
+                new_data[key] = np.load(value)
 
         return cls(xeb_config, circuits, new_data, data_handler)
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -765,8 +765,12 @@ class XEBResult:
         depths = self.xeb_config.depths
         counts = self.counts
         states = self.states
-        expected_probs = np.zeros((seqs, len(depths), dim))
-        disjoint_expected_probs = np.zeros((n_qubits, seqs, len(depths), dim))
+        if "joint_expected_probs" not in self.data.keys():
+            expected_probs = np.zeros((seqs, len(depths), dim))
+            disjoint_expected_probs = np.zeros((n_qubits, seqs, len(depths), dim))
+        else:
+            expected_probs = self.data["joint_expected_probs"]
+            disjoint_expected_probs = self.data["disjoint_expected_probs"]
         if not self.xeb_config.disjoint_processing:
             records, singularity, outlier = [], [], []
             incoherent_distribution = np.ones(dim) / dim
@@ -774,12 +778,11 @@ class XEBResult:
             log_fidelities = np.zeros((seqs, len(depths)))
 
         else:
+            measured_probs = np.zeros((n_qubits, seqs, len(depths), 2))
             records = [[] for _ in range(n_qubits)]
             singularity = [[] for _ in range(n_qubits)]
             outlier = [[] for _ in range(n_qubits)]
             incoherent_distribution = np.ones(2) / 2
-            expected_probs = np.zeros((n_qubits, seqs, len(depths), 2))
-            measured_probs = np.zeros((n_qubits, seqs, len(depths), 2))
             log_fidelities = np.zeros((n_qubits, seqs, len(depths)))
 
         for s in range(seqs):
@@ -792,10 +795,6 @@ class XEBResult:
                         disjoint_expected_probs[q, s, d_] = np.round(
                             statevector.probabilities([q]), 5
                         )
-                else:
-                    expected_probs[s, d_] = self.data["joint_expected_probs"][s, d_]
-                    for q in range(n_qubits):
-                        disjoint_expected_probs[q, s, d_] = self.data["disjoint_expected_probs"][q, s, d_]
 
                 if not self.xeb_config.disjoint_processing:
                     measured_probs[s, d_] = (

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -1008,7 +1008,6 @@ class XEBResult:
 
         """
         depths = self.xeb_config.depths
-        n_qubits = self.xeb_config.n_qubits
         colors = sns.cubehelix_palette(n_colors=len(depths))
         colors = {k: colors[i] for i, k in enumerate(depths)}
         _lines = []
@@ -1075,7 +1074,7 @@ class XEBResult:
                 for j in range(2):
                     titles.append(f"{q}<{j}> Measured")
                     titles.append(f"{q}<{j}> Expected")
-                    data.append(self.measured_probs[i, :, :, j])
+                    data.append(self.disjoint_measured_probs[i, :, :, j])
                     data.append(self.disjoint_expected_probs[i, :, :, j])
 
         num_plots = len(titles)
@@ -1124,6 +1123,14 @@ class XEBResult:
         Returns: Measured probabilities of the states
         """
         return self._joint_measured_probs
+    
+    @property
+    def disjoint_measured_probs(self):
+        """
+        Measured probabilities of the states for disjoint processing
+        Returns: Measured probabilities of the states for disjoint processing
+        """
+        return self._disjoint_measured_probs
 
     @property
     def expected_probs(self):

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -605,8 +605,8 @@ class XEBJob:
         return XEBResult(
             self.xeb_config,
             self.circuits,
-            states,
             counts,
+            states,
             saved_data,
             self.data_handler if self.xeb_config.should_save_data else None,
         )
@@ -670,7 +670,7 @@ class XEBJob:
 
 class XEBResult:
     def __init__(
-        self, xeb_config: XEBConfig, circuits, states: Dict, counts: Dict, saved_data, data_handler: DataHandler = None
+        self, xeb_config: XEBConfig, circuits, counts: Dict, states: Dict, saved_data, data_handler: DataHandler = None
     ):
         self.xeb_config = xeb_config
         self.circuits: List[List[QuantumCircuit]] = circuits

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -879,12 +879,14 @@ class XEBResult:
             outlier,
         )
 
-    def plot_fidelities(self, fit_linear: bool = True, fit_log_entropy: bool = True):
+    def plot_fidelities(self, fit_linear: bool = True, fit_log_entropy: bool = True, separate_plots: bool = False):
         """
         Plot the cross-entropy fidelities for the XEB experiment
         Args:
             fit_linear: Indicate if the linear XEB data should be fitted
             fit_log_entropy: Indicate if the log-entropy XEB data should be fitted
+            separate_plots: Indicate if the fidelities should be plotted on separate plots (one per qubit, relevant 
+                only when disjoint_processing is True)
         Returns:
         """
 
@@ -892,7 +894,8 @@ class XEBResult:
 
         if self.xeb_config.disjoint_processing:
             for q, qubit in enumerate(self.qubit_names):
-                plt.figure()
+                if separate_plots:
+                    plt.figure()
                 linear_fidelities = self.linear_fidelities[q]
                 xx = np.linspace(0, linear_fidelities["depth"].max())
                 try:  # Fit the data for the linear XEB

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -584,7 +584,7 @@ class XEBJob:
             saved_data = {"counts": counts, "states": states, "density_matrices": dms}
         else:
 
-            gate_indices = states = counts = quadratures = amp_st = {}
+            gate_indices, states, counts, quadratures, amp_st = {}, {}, {}, {}, {}
             result = self._result_handles
             for q, qubit in enumerate(self.xeb_config.qubits):
                 gate_indices[f"g_{qubit.name}"] = result.get(f"g{q}").fetch_all()["value"]

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb.py
@@ -1,14 +1,11 @@
 import json
 import warnings
-from dataclasses import asdict
 from typing import Union, List, Optional, Dict, Tuple
 import numpy as np
-from qiskit import QuantumRegister
 from qm.qua import *
 from .macros import (
     qua_declaration,
     reset_qubit,
-    cross_entropy,
     binary,
     exponential_decay,
     fit_exponential_decay,
@@ -30,13 +27,11 @@ from qiskit.transpiler import CouplingMap
 from qiskit.quantum_info import Statevector
 from qualang_tools.results import DataHandler
 
-from quam_libs.components import QuAM, Transmon, TransmonPair
-from quam_libs.macros import multiplexed_readout, node_save
+from quam_libs.components import QuAM, Transmon
 from qm import SimulationConfig, QuantumMachinesManager
 from qm.jobs.running_qm_job import RunningQmJob
 from qm.jobs.simulated_job import SimulatedJob
 import seaborn as sns
-from copy import deepcopy
 from warnings import warn
 
 from qualang_tools.units import unit
@@ -213,9 +208,9 @@ class XEB:
             r.set_seed(12321)
 
             # If simulating, update the frequency to 0 to visualize sequence
-            if simulate:
-                for qubit in self.qubit_drive_channels:
-                    update_frequency(qubit.name, 0)
+            # if simulate:
+                # for qubit in self.qubit_drive_channels:
+                #     update_frequency(qubit.name, 0)
 
             # Generate the random sequences
             with for_(s, 0, s < self.xeb_config.seqs, s + 1):
@@ -601,7 +596,6 @@ class XEBJob:
                 **quadratures,
                 **states,
                 **counts,
-                **gate_indices,
                 **amp_st,
                 "gate_indices": self.gate_indices,
                 "gate_sequences": self.gate_sequences,

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -82,7 +82,7 @@ class XEBConfig:
             "gate_set_choice": self.gate_set_choice,
             "two_qb_gate": self.two_qb_gate.name if self.two_qb_gate else None,
             "qubit_pairs": [pair.name for pair in self.qubit_pairs],
-            "coupling_map": self.coupling_map,
+            "coupling_map": list(self.coupling_map.get_edges()) if self.coupling_map else None,
             "available_combinations": self.available_combinations,
         }
         return config_dict

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -92,7 +92,7 @@ class XEBConfig:
         """
         Create an XEBConfig object from a dictionary that contains all relevant parameters.
         This method will usually be used to load a configuration from previously saved data from another run.
-        
+
         Args:
             config_dict (Dict): Dictionary containing the configuration parameters
             machine (Optional[QuAM]): QuAM object containing the qubits and qubit pairs used in the experiment

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -89,7 +89,7 @@ class XEBConfig:
             "qubits": [qubit.name for qubit in self.qubits],
             "baseline_gate_name": self.baseline_gate_name,
             "gate_set_choice": self.gate_set_choice,
-            "two_qb_gate": self.two_qb_gate.name,
+            "two_qb_gate": self.two_qb_gate.name if self.two_qb_gate else None,
             "qubit_pairs": [pair.name for pair in self.qubit_pairs],
             "coupling_map": list(self.coupling_map.get_edges()),
             "available_combinations": self.available_combinations,

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -84,7 +84,7 @@ class XEBConfig:
         """
         config_dict = {
             "seqs": self.seqs,
-            "depths": self.depths,
+            "depths": self.depths.tolist(),
             "n_shots": self.n_shots,
             "qubits": [qubit.name for qubit in self.qubits],
             "baseline_gate_name": self.baseline_gate_name,

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -6,7 +6,7 @@ from qiskit.transpiler import CouplingMap
 
 from .gateset import QUAGateSet
 from .qua_gate import QUAGate
-from ...components import Transmon, TransmonPair
+from ...components import Transmon, TransmonPair, QuAM
 from .macros import get_parallel_gate_combinations as gate_combinations
 
 
@@ -38,8 +38,8 @@ class XEBConfig:
     seqs: int
     depths: Union[np.ndarray, List[int]]
     n_shots: int
-    readout_qubits: List[Transmon]
     qubits: List[Transmon]
+    readout_qubits: Optional[List[Transmon]] = None
     baseline_gate_name: str = "sx"
     gate_set_choice: Union[Literal["sw", "t"], Dict[int, QUAGate]] = "sw"
     two_qb_gate: Optional[QUAGate] = None
@@ -95,3 +95,27 @@ class XEBConfig:
             "available_combinations": self.available_combinations,
         }
         return config_dict
+
+    @classmethod
+    def from_dict(cls, config_dict: Dict, machine: Optional[QuAM] = None):
+        """
+        Create an XEBConfig object from a dictionary
+        """
+        qubits_names = config_dict["qubits"]
+        qubits = [machine.qubits[qubit_name] if machine is not None else qubit_name for qubit_name in qubits_names]
+        qubit_pairs_names = config_dict["qubit_pairs"]
+        qubit_pairs = [
+            machine.qubit_pairs[qubit_pair_name] if machine is not None else qubit_pair_name
+            for qubit_pair_name in qubit_pairs_names
+        ]
+        two_qb_gate = QUAGate(config_dict["two_qb_gate"]) if config_dict["two_qb_gate"] else None
+        return cls(
+            seqs=config_dict["seqs"],
+            depths=config_dict["depths"],
+            n_shots=config_dict["n_shots"],
+            qubits=qubits,
+            baseline_gate_name=config_dict["baseline_gate_name"],
+            gate_set_choice=config_dict["gate_set_choice"],
+            two_qb_gate=two_qb_gate,
+            qubit_pairs=qubit_pairs,
+        )

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/two_qubit_xeb/xeb_config.py
@@ -77,11 +77,11 @@ class XEBConfig:
             "seqs": self.seqs,
             "depths": self.depths.tolist(),
             "n_shots": self.n_shots,
-            "qubits": [qubit.name for qubit in self.qubits],
+            "qubits": [qubit.name if isinstance(qubit, Transmon) else qubit for qubit in self.qubits],
             "baseline_gate_name": self.baseline_gate_name,
             "gate_set_choice": self.gate_set_choice,
             "two_qb_gate": self.two_qb_gate.name if self.two_qb_gate else None,
-            "qubit_pairs": [pair.name for pair in self.qubit_pairs],
+            "qubit_pairs": [pair.name if isinstance(pair, TransmonPair) else pair for pair in self.qubit_pairs],
             "coupling_map": list(self.coupling_map.get_edges()) if self.coupling_map else None,
             "available_combinations": self.available_combinations,
         }


### PR DESCRIPTION
Refactoring was done to enable the possibility to generate a XEBResult class from existing data that has been saved through the DataHandler previously.

Moreover, the simulation backend was adjusted such that the basis gates are consistent.

A new argument data_folder_name was added to the XEBConfig class such that one can choose which name to give to the saved data file.

Coupling map is now an attribute of the XEBConfig, as it can be inferred directly from qubits and qubit pairs.
XEBConfig also has a new method as_dict, converting it easily to data fields that are saved into a json file.

An extra optional field was added to the XEB.run method, enabling the user to specify a custom QuantumMachinesManager instance in case they want to simulate the program on the OPX Cloud simulator.