### PR TITLE
Some Fix and Suggestion on `classical_shadow`

### DIFF
--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/components/transmon.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/components/transmon.py
@@ -77,9 +77,13 @@ class Transmon(Qubit):
         """The 0-2 (e-f) transition frequency in Hz, derived from f_01 and anharmonicity"""
         name = getattr(self, "name", self.__class__.__name__)
         if not isinstance(self.f_01, (float, int)):
-            raise AttributeError(f"Error inferring f_12 for channel {name}: {self.f_01=} is not a number")
+            raise AttributeError(
+                f"Error inferring f_12 for channel {name}: {self.f_01=} is not a number"
+            )
         if not isinstance(self.anharmonicity, (float, int)):
-            raise AttributeError(f"Error inferring f_12 for channel {name}: {self.anharmonicity=} is not a number")
+            raise AttributeError(
+                f"Error inferring f_12 for channel {name}: {self.anharmonicity=} is not a number"
+            )
         return self.f_01 + self.anharmonicity
 
     @property
@@ -87,9 +91,13 @@ class Transmon(Qubit):
         """The transmon anharmonicity in Hz, derived from f_01 and f_12."""
         name = getattr(self, "name", self.__class__.__name__)
         if not isinstance(self.f_01, (float, int)):
-            raise AttributeError(f"Error inferring anharmonicity for channel {name}: {self.f_01=} is not a number")
+            raise AttributeError(
+                f"Error inferring anharmonicity for channel {name}: {self.f_01=} is not a number"
+            )
         if not isinstance(self.f_12, (float, int)):
-            raise AttributeError(f"Error inferring anharmonicity for channel {name}: {self.f_12=} is not a number")
+            raise AttributeError(
+                f"Error inferring anharmonicity for channel {name}: {self.f_12=} is not a number"
+            )
         return self.f_12 - self.f_01
 
     # @property
@@ -102,7 +110,10 @@ class Transmon(Qubit):
         return int(self.thermalization_time_factor * self.T1 * 1e9 / 4) * 4
 
     def calibrate_octave(
-        self, QM: QuantumMachine, calibrate_drive: bool = True, calibrate_resonator: bool = True
+        self,
+        QM: QuantumMachine,
+        calibrate_drive: bool = True,
+        calibrate_resonator: bool = True,
     ) -> None:
         """Calibrate the Octave channels (xy and resonator) linked to this transmon for the LO frequency, intermediate
         frequency and Octave gain as defined in the state.
@@ -143,19 +154,25 @@ class Transmon(Qubit):
     def __matmul__(self, other):
         if not isinstance(other, Transmon):
             raise ValueError(
-                "Cannot create a qubit pair (q1 @ q2) with a non-qubit object, " f"where q1={self} and q2={other}"
+                "Cannot create a qubit pair (q1 @ q2) with a non-qubit object, "
+                f"where q1={self} and q2={other}"
             )
 
         if self is other:
-            raise ValueError("Cannot create a qubit pair with same qubit (q1 @ q1), where q1={self}")
+            raise ValueError(
+                "Cannot create a qubit pair with same qubit (q1 @ q1), where q1={self}"
+            )
 
-        for qubit_pair in self._root.qubit_pairs.values():
+        for qubit_pair in self.get_root().qubit_pairs.values():
             if qubit_pair.qubit_control is self and qubit_pair.qubit_target is other:
                 return qubit_pair
         else:
-            raise ValueError("Qubit pair not found: qubit_control={self.name}, " "qubit_target={other.name}")
+            raise ValueError(
+                "Qubit pair not found: qubit_control={self.name}, "
+                "qubit_target={other.name}"
+            )
 
-    def align(self, other = None):
+    def align(self, other=None):
         channels = [self.xy.name, self.resonator.name, self.z.name]
 
         if other is not None:

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/classical_shadow.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/classical_shadow.py
@@ -21,6 +21,9 @@ from ..two_qubit_xeb.macros import qua_declaration, reset_qubit, binary
 
 u = unit(coerce_to_integer=True)
 
+BASIS_GATES_SINGLE_QUBIT = ["sx", "x", "rz", "measure", "reset", "y"]
+BASIS_GATES_TWO_QUBIT = ["cz"]
+
 
 def create_target(machine: QuAM):
     qubit_pairs_mapping = {
@@ -39,7 +42,7 @@ def create_target(machine: QuAM):
     two_qubit_prop = {
         qubit_pairs_mapping[pair.name]: None for pair in machine.active_qubit_pairs
     }
-    for instr in ["sx", "x", "rz", "measure", "reset", "y"]:
+    for instr in BASIS_GATES_SINGLE_QUBIT:
         target.add_instruction(gate_map[instr], single_qubit_prop)
     target.add_instruction(gate_map["cz"], two_qubit_prop)
     return target
@@ -57,8 +60,11 @@ def qiskit_to_qua_macro(
         else None
     )
     target = create_target(machine)
+    qc_raw_transpiled = transpile(
+        circuit, basis_gates=BASIS_GATES_SINGLE_QUBIT + BASIS_GATES_TWO_QUBIT
+    )
     qc = transpile(
-        circuit,
+        qc_raw_transpiled,
         target=target,
         initial_layout=initial_layout,
         optimization_level=optimization_level,
@@ -321,7 +327,7 @@ class ClassicalShadowJob:
         shadow_size = self.config.shadow_size
         gates = self._result_handles["random_basis"].fetch_all()["value"]
         input_state_circuit = self.config.input_state_circuit(
-            **self.config.input_state_prep_macro_kwargs
+            **self.config.input_state_circuit_kwargs
         )
         for i in range(shadow_size):
             for j in range(self.config.n_qubits):
@@ -332,7 +338,8 @@ class ClassicalShadowJob:
             circuits[i].compose(input_state_circuit, inplace=True)
             for j in range(self.config.n_qubits):
                 circuits[i].append(
-                    self.config.measurement_basis[self._gate_indices[i, j]].gate, [j]
+                    self.config.measurement_basis[self._gate_indices[i, j]].to_gate(),
+                    [j],
                 )
         return circuits
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/classical_shadow.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/classical_shadow.py
@@ -21,60 +21,90 @@ from ..two_qubit_xeb.macros import qua_declaration, reset_qubit, binary
 
 u = unit(coerce_to_integer=True)
 
+
 def create_target(machine: QuAM):
-    qubit_pairs_mapping = {qubit_pair.name: (machine.active_qubits.index(qubit_pair.qubit_control), machine.active_qubits.index(qubit_pair.qubit_target)) for qubit_pair in machine.active_qubit_pairs}
-    
-    target = Target('quam', len(machine.active_qubits),
-    dt=1e-9, granularity=4, min_length=16)
+    qubit_pairs_mapping = {
+        qubit_pair.name: (
+            machine.active_qubits.index(qubit_pair.qubit_control),
+            machine.active_qubits.index(qubit_pair.qubit_target),
+        )
+        for qubit_pair in machine.active_qubit_pairs
+    }
+
+    target = Target(
+        "quam", len(machine.active_qubits), dt=1e-9, granularity=4, min_length=16
+    )
     gate_map = get_standard_gate_name_mapping()
     single_qubit_prop = {(i,): None for i in range(len(machine.active_qubits))}
-    two_qubit_prop = {qubit_pairs_mapping[pair.name]: None for pair in machine.active_qubit_pairs}
+    two_qubit_prop = {
+        qubit_pairs_mapping[pair.name]: None for pair in machine.active_qubit_pairs
+    }
     for instr in ["sx", "x", "rz", "measure", "reset", "y"]:
         target.add_instruction(gate_map[instr], single_qubit_prop)
     target.add_instruction(gate_map["cz"], two_qubit_prop)
     return target
 
 
-def qiskit_to_qua_macro(circuit: QuantumCircuit, machine: QuAM, target_qubits: List[Transmon] | None = None, optimization_level: Optional[int] = None):
-    initial_layout = [machine.active_qubits.index(qubit) for qubit in target_qubits] if target_qubits is not None else None
-    if optimization_level is not None:
-        target = create_target(machine)
-        qc = transpile(circuit, target=target, initial_layout=initial_layout, optimization_level=optimization_level)
-    else:
-        qc = circuit
-    qubit_indices = {qubit: qc.find_bit(qubit).index for i, qubit in enumerate(qc.qubits)}
-    
-    cregs = {creg.name: declare(bool, value= [False] * creg.size) for creg in qc.cregs}
-    
+def qiskit_to_qua_macro(
+    circuit: QuantumCircuit,
+    machine: QuAM,
+    target_qubits: List[Transmon] | None = None,
+    optimization_level: Optional[int] = None,
+):
+    initial_layout = (
+        [machine.active_qubits.index(qubit) for qubit in target_qubits]
+        if target_qubits is not None
+        else None
+    )
+    target = create_target(machine)
+    qc = transpile(
+        circuit,
+        target=target,
+        initial_layout=initial_layout,
+        optimization_level=optimization_level,
+    )
+    qubit_indices = {
+        qubit: qc.find_bit(qubit).index for i, qubit in enumerate(qc.qubits)
+    }
+
+    cregs = {creg.name: declare(bool, value=[False] * creg.size) for creg in qc.cregs}
+
     for instruction in qc.data:
         try:
             qubits = instruction.qubits
             if instruction.operation.name == "barrier":
-               continue
+                continue
             if len(qubits) == 2:
                 qubit_control = machine.active_qubits[qubit_indices[qubits[0]]]
                 qubit_target = machine.active_qubits[qubit_indices[qubits[1]]]
                 qubit_pair = qubit_control @ qubit_target
-                qubit_pair.apply(instruction.operation.name, *instruction.operation.params)
+                qubit_pair.apply(
+                    instruction.operation.name, *instruction.operation.params
+                )
             elif len(qubits) == 1:
                 qubit = machine.active_qubits[qubit_indices[qubits[0]]]
-                result = qubit.apply(instruction.operation.name, *instruction.operation.params)
+                result = qubit.apply(
+                    instruction.operation.name, *instruction.operation.params
+                )
                 if instruction.clbits:
                     for clbit in instruction.clbits:
                         registers = qc.find_bit(clbit).registers
                         if len(registers) > 1:
-                            raise ValueError(f"Multiple registers found for clbit: {clbit}")
+                            raise ValueError(
+                                f"Multiple registers found for clbit: {clbit}"
+                            )
                         creg, index = registers[0]
-                        assign(cregs[creg.name][index], result)    
-                        
+                        assign(cregs[creg.name][index], result)
+
             else:
                 raise ValueError(f"Unsupported number of qubits: {len(qubits)}")
         except Exception as e:
             print(f"Error processing instruction: {instruction}")
             raise e
-    
+
     return cregs
-   
+
+
 class ClassicalShadow:
     def __init__(
         self,
@@ -90,24 +120,31 @@ class ClassicalShadow:
         """
         self.config = config
         self.machine = machine
-        self.data_handler = DataHandler(name="classical_shadow",
-                                        root_data_folder=self.config.save_dir)
-        
-    
+        self.data_handler = DataHandler(
+            name="classical_shadow", root_data_folder=self.config.save_dir
+        )
+
     def cs_prog(self, simulate: bool = False) -> Program:
-        
         """
         Generate the QUA script for the classical shadow experiment.
         """
         n_qubits = self.config.n_qubits
         dim = self.config.dim
-        random_gates = len(self.config.measurement_basis) if self.config.measurement_basis is not None else 3
-        ge_thresholds = [qubit.resonator.operations[self.config.readout_pulse_name].threshold 
-                         for qubit in self.config.qubits]
-        
+        random_gates = (
+            len(self.config.measurement_basis)
+            if self.config.measurement_basis is not None
+            else 3
+        )
+        ge_thresholds = [
+            qubit.resonator.operations[self.config.readout_pulse_name].threshold
+            for qubit in self.config.qubits
+        ]
+
         with program() as cs_prog:
-            I, I_st, Q, Q_st = qua_declaration(n_qubits=n_qubits, 
-                                               readout_elements=[qubit.resonator for qubit in self.config.qubits],)
+            I, I_st, Q, Q_st = qua_declaration(
+                n_qubits=n_qubits,
+                readout_elements=[qubit.resonator for qubit in self.config.qubits],
+            )
             random_basis = declare(int, size=n_qubits)
             random_basis_stream = declare_stream()
             state = declare(bool, size=self.config.n_qubits)
@@ -118,16 +155,18 @@ class ClassicalShadow:
             j = declare(int)
             shot = declare(int)
             if self.config.gate_indices is not None:
-                gate_indices = [declare(int,
-                                         value=self.config.gate_indices[:, n].tolist()) for n in range(n_qubits)]
-            
+                gate_indices = [
+                    declare(int, value=self.config.gate_indices[:, n].tolist())
+                    for n in range(n_qubits)
+                ]
+
             self.machine.apply_all_flux_to_min()
             self.machine.apply_all_couplers_to_min()
-            
+
             if simulate:
                 for qubit in self.config.qubits:
                     qubit.xy.update_frequency(0)
-                    
+
             with for_(i, 0, i < self.config.shadow_size, i + 1):
                 # Possible wait time before the experiment
                 # wait(...)
@@ -143,83 +182,121 @@ class ClassicalShadow:
 
                 with for_(shot, 0, shot < self.config.shots_per_snapshot, shot + 1):
                     # Prepare state
-                    if self.config.input_state_circuit_kwargs: #is not None:
-                        qiskit_to_qua_macro(self.config.input_state_circuit(**self.config.input_state_circuit_kwargs), self.machine, self.config.target_qubits)
+                    if self.config.input_state_circuit_kwargs:  # is not None:
+                        qiskit_to_qua_macro(
+                            self.config.input_state_circuit(
+                                **self.config.input_state_circuit_kwargs
+                            ),
+                            self.machine,
+                            self.config.target_qubits,
+                        )
                     else:
-                        qiskit_to_qua_macro(self.config.input_state_circuit(), self.machine, self.config.target_qubits)
+                        qiskit_to_qua_macro(
+                            self.config.input_state_circuit(),
+                            self.machine,
+                            self.config.target_qubits,
+                        )
                     align()
 
                     if self.config.measurement_basis is not None:
-                        for q, qubit, in enumerate(self.config.qubits):
+                        for (
+                            q,
+                            qubit,
+                        ) in enumerate(self.config.qubits):
                             with switch_(random_basis[q], unsafe=False):
                                 # Apply the random basis rotation
                                 for k in range(random_gates):
                                     with case_(k):
-                                        qiskit_to_qua_macro(self.config.measurement_basis[k], self.machine, [qubit])
+                                        qiskit_to_qua_macro(
+                                            self.config.measurement_basis[k],
+                                            self.machine,
+                                            [qubit],
+                                        )
                     else:
-                        for q, qubit, in enumerate(self.config.qubits):
-                        # Replace switch case with conditional plays of the measurement basis rotations
+                        for (
+                            q,
+                            qubit,
+                        ) in enumerate(self.config.qubits):
+                            # Replace switch case with conditional plays of the measurement basis rotations
                             qubit.xy.play("x90", condition=random_basis[q] == 0)
                             qubit.xy.play("-y90", condition=random_basis[q] == 1)
-        
+
                     # Readout
                     # Play the readout on the other resonator to measure in the same condition as when optimizing readout
                     for other_qubit in self.config.readout_qubits:
-                        if other_qubit.resonator not in [qubit.resonator for qubit in self.config.qubits]:
+                        if other_qubit.resonator not in [
+                            qubit.resonator for qubit in self.config.qubits
+                        ]:
                             other_qubit.resonator.play("readout")
-                    for q, qubit, in enumerate(self.config.qubits):
+                    for (
+                        q,
+                        qubit,
+                    ) in enumerate(self.config.qubits):
                         # qubit.align()
-                        qubit.resonator.measure(self.config.readout_pulse_name,
-                                                qua_vars=(I[q], Q[q]))
+                        qubit.resonator.measure(
+                            self.config.readout_pulse_name, qua_vars=(I[q], Q[q])
+                        )
                         # State Estimation: returned as integer
                         assign(state[q], I[q] > ge_thresholds[q])
-                        assign(state_int, state_int + (1<<q) * Cast.to_int(state[q]))
+                        assign(state_int, state_int + (1 << q) * Cast.to_int(state[q]))
 
-                        reset_qubit(self.config.reset_method,
-                                    qubit,
-                                    threshold=ge_thresholds[q],
-                                    **self.config.reset_kwargs)
+                        reset_qubit(
+                            self.config.reset_method,
+                            qubit,
+                            threshold=ge_thresholds[q],
+                            **self.config.reset_kwargs,
+                        )
                     save(state_int, state_int_stream)
                     assign(state_int, 0)
-                
+
             with stream_processing():
                 random_basis_stream.buffer(n_qubits).save_all("random_basis")
-                state_int_stream.buffer(self.config.shots_per_snapshot).save_all("state_int")
-        
+                state_int_stream.buffer(self.config.shots_per_snapshot).save_all(
+                    "state_int"
+                )
+
         return cs_prog
-    
-    def run(self, simulate: bool = False,
-            simulation_config: Optional[SimulationConfig] = None,
-            qmm_cloud_simulator: Optional[QuantumMachinesManager] = None,
-            **simulate_kwargs):
+
+    def run(
+        self,
+        simulate: bool = False,
+        simulation_config: Optional[SimulationConfig] = None,
+        qmm_cloud_simulator: Optional[QuantumMachinesManager] = None,
+        **simulate_kwargs,
+    ):
         config = self.machine.generate_config()
         if simulation_config is None:
-            simulation_config = SimulationConfig(
-                duration=10_000
-            )
+            simulation_config = SimulationConfig(duration=10_000)
         cs_prog = self.cs_prog(simulate=simulate)
         if simulate and qmm_cloud_simulator is not None:
             qmm = qmm_cloud_simulator
         else:
             qmm = self.machine.connect()
-        
+
         qm = qmm.open_qm(config)
         if simulate:
             with open("debug.py", "w+") as f:
                 f.write(generate_qua_script(cs_prog, config))
             job = qm.simulate(cs_prog, simulate=simulation_config, **simulate_kwargs)
-            
+
         elif self.config.generate_new_data:
             job = qm.execute(cs_prog)
         else:
-            warnings.warn("No new data will be generated. Please set generate_new_data to True to generate new data.")
-            return 
-        
+            warnings.warn(
+                "No new data will be generated. Please set generate_new_data to True to generate new data."
+            )
+            return
+
         return ClassicalShadowJob(job, self.config, self.data_handler)
-        
-            
+
+
 class ClassicalShadowJob:
-    def __init__(self, job: RunningQmJob | SimulatedJob, config: ShadowConfig, data_handler: DataHandler):
+    def __init__(
+        self,
+        job: RunningQmJob | SimulatedJob,
+        config: ShadowConfig,
+        data_handler: DataHandler,
+    ):
         """
         Initialize the ClassicalShadowJob object.
 
@@ -233,45 +310,52 @@ class ClassicalShadowJob:
         self._result_handles.wait_for_all_values()
         self.config = config
         self.data_handler = data_handler
-        self._gate_indices = np.zeros((self.config.shadow_size, self.config.n_qubits), dtype=int)
-        
-        
+        self._gate_indices = np.zeros(
+            (self.config.shadow_size, self.config.n_qubits), dtype=int
+        )
+
     def _get_circuits(self):
         """
         Get the circuits from the job.
         """
         shadow_size = self.config.shadow_size
-        gates = self._result_handles["random_basis"].fetch_all()['value']
-        input_state_circuit = self.config.input_state_circuit(**self.config.input_state_prep_macro_kwargs)
+        gates = self._result_handles["random_basis"].fetch_all()["value"]
+        input_state_circuit = self.config.input_state_circuit(
+            **self.config.input_state_prep_macro_kwargs
+        )
         for i in range(shadow_size):
             for j in range(self.config.n_qubits):
                 self._gate_indices[i, j] = gates[i][j]
-                
+
         circuits = [QuantumCircuit(self.config.n_qubits) for _ in range(shadow_size)]
         for i in range(shadow_size):
             circuits[i].compose(input_state_circuit, inplace=True)
             for j in range(self.config.n_qubits):
-                circuits[i].append(self.config.measurement_basis[self._gate_indices[i, j]].gate,
-                                   [j])
+                circuits[i].append(
+                    self.config.measurement_basis[self._gate_indices[i, j]].gate, [j]
+                )
         return circuits
-    
+
     def result(self):
         """
         Get the result of the job.
         """
-        state_ints = self._result_handles["state_int"].fetch_all()['value']
+        state_ints = self._result_handles["state_int"].fetch_all()["value"]
         bitstrings = []
         for i, state_int in enumerate(state_ints):
             # Count all occurences of each bitstring and build a dictionary of counted bitstrings
-            counts = {binary(i, self.config.n_qubits): 0 for i in range(self.config.dim)}
+            counts = {
+                binary(i, self.config.n_qubits): 0 for i in range(self.config.dim)
+            }
             for j in range(len(state_int)):
                 bitstring = binary(state_int[j], self.config.n_qubits)
                 counts[bitstring] += 1
             bitstrings.append(counts)
 
-        return [(bitstring, self._gate_indices[i]) for i, bitstring in enumerate(bitstrings)]
-    
-    
+        return [
+            (bitstring, self._gate_indices[i]) for i, bitstring in enumerate(bitstrings)
+        ]
+
     def ideal_result(self):
         """
         Get the ideal results of the job.
@@ -282,10 +366,5 @@ class ClassicalShadowJob:
             state = Statevector(circuit)
             probs = state.probabilities_dict()
             results.append((probs, self._gate_indices[i]))
-            
+
         return results
-            
-            
-            
-            
-     

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/shadow_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/shadow_config.py
@@ -9,6 +9,7 @@ from .additional_gates import SYdgGate
 from qiskit.quantum_info import Operator
 import numpy as np
 
+
 @dataclass
 class ShadowConfig:
     """
@@ -25,8 +26,9 @@ class ShadowConfig:
     readout_qubits: Optional[List[Transmon]] = Readout qubits
     readout_pulse_name: str = Readout pulse name
     reset_method: Literal["active", "cooldown"] = Reset method
-        
+
     """
+
     shadow_size: int
     shots_per_snapshot: int
     input_state_circuit: Callable[[Any], QuantumCircuit]
@@ -34,6 +36,7 @@ class ShadowConfig:
     measurement_basis: Optional[Dict[int, QuantumCircuit]] = None
     input_state_circuit_kwargs: Optional[Dict[str, Any]] = None
     readout_qubits: Optional[List[Transmon]] = None
+    target_qubits: Optional[List[Transmon]] = None
     readout_pulse_name: str = "readout"
     reset_method: Literal["active", "cooldown"] = "cooldown"
     reset_kwargs: Optional[Dict[str, Union[float, str, int]]] = field(
@@ -43,17 +46,17 @@ class ShadowConfig:
             "pi_pulse": None,
         }
     )
-    gate_indices: List[List[int]]| np.ndarray | None = None
+    gate_indices: List[List[int]] | np.ndarray | None = None
     save_dir: str = ""
     should_save_data: bool = True
     data_folder_name: Optional[str] = None
     generate_new_data: bool = True
     seed: int = 1234
-    
+
     def __post_init__(self):
         self.n_qubits = len(self.qubits)
         self.dim = 2**self.n_qubits
-        
+
         if self.gate_indices is not None:
             if isinstance(self.gate_indices, list):
                 self.gate_indices = np.array(self.gate_indices)
@@ -61,28 +64,50 @@ class ShadowConfig:
             if self.gate_indices.ndim != 2:
                 raise ValueError("gate_indices must be a 2D array")
             if self.gate_indices.shape[1] != self.n_qubits:
-                raise ValueError("gate_indices must have the same number of columns as the number of qubits")
+                raise ValueError(
+                    "gate_indices must have the same number of columns as the number of qubits"
+                )
             if self.gate_indices.shape[0] != self.shadow_size:
-                raise ValueError("gate_indices must have the same number of rows as the shadow size")
+                raise ValueError(
+                    "gate_indices must have the same number of rows as the shadow size"
+                )
             # Check if there is no index that is negative or higher than length of dictionary of macros
             if self.measurement_basis is not None:
                 if not isinstance(self.measurement_basis, dict):
                     raise ValueError("measurement_basis must be a dictionary")
-                if not all(isinstance(key, int) and key >= 0 for key in self.measurement_basis.keys()):
+                if not all(
+                    isinstance(key, int) and key >= 0
+                    for key in self.measurement_basis.keys()
+                ):
                     raise ValueError("measurement_basis keys must be positive integers")
-                if not all(isinstance(value, QuantumCircuit) for value in self.measurement_basis.values()):
-                    raise ValueError("measurement_basis values must be QuantumCircuit objects")
-                if any(index < 0 or index > len(self.measurement_basis) - 1 for index in self.gate_indices.flatten()):
-                    raise ValueError("gate_indices must contain only indices that are within the range of the measurement basis")
+                if not all(
+                    isinstance(value, QuantumCircuit)
+                    for value in self.measurement_basis.values()
+                ):
+                    raise ValueError(
+                        "measurement_basis values must be QuantumCircuit objects"
+                    )
+                if any(
+                    index < 0 or index > len(self.measurement_basis) - 1
+                    for index in self.gate_indices.flatten()
+                ):
+                    raise ValueError(
+                        "gate_indices must contain only indices that are within the range of the measurement basis"
+                    )
                 for i in range(len(self.measurement_basis)):
                     try:
                         op = Operator(self.measurement_basis[i])
-                        assert op.num_qubits == 1, "All unitary operations in the measurement basis must be single qubit operations, but {i} has {op.num_qubits} qubits"
-                        assert op.is_unitary(), "All unitary operations in the measurement basis must be unitary, but {i} is not"
+                        assert op.num_qubits == 1, (
+                            "All unitary operations in the measurement basis must be single qubit operations, but {i} has {op.num_qubits} qubits"
+                        )
+                        assert op.is_unitary(), (
+                            "All unitary operations in the measurement basis must be unitary, but {i} is not"
+                        )
                     except Exception as e:
-                        raise ValueError(f"Measurement basis {i} is not a valid unitary operation (make sure to not add the measurement instruction): {e}")
-            
-        
+                        raise ValueError(
+                            f"Measurement basis {i} is not a valid unitary operation (make sure to not add the measurement instruction): {e}"
+                        )
+
     def as_dict(self):
         """
         Return the ShadowConfig object as a dictionary
@@ -90,27 +115,40 @@ class ShadowConfig:
         config_dict = {
             "shadow_size": self.shadow_size,
             "measurement_basis": self.measurement_basis,
-            "qubits": [qubit.name if isinstance(qubit, Transmon) else qubit for qubit in self.qubits],
+            "qubits": [
+                qubit.name if isinstance(qubit, Transmon) else qubit
+                for qubit in self.qubits
+            ],
             "seed": self.seed,
         }
         return config_dict
-    
+
     @property
     def random_unitary_set(self):
         """
         Return the unitary operations of the measurement basis
         """
         if self.measurement_basis is None:
-            return {0: SXGate().to_matrix(), 1: SYdgGate().to_matrix(), 2: ZGate().to_matrix()}
-        return {i: Operator(self.measurement_basis[i]).to_matrix() for i in range(len(self.measurement_basis))}
-    
+            return {
+                0: SXGate().to_matrix(),
+                1: SYdgGate().to_matrix(),
+                2: ZGate().to_matrix(),
+            }
+        return {
+            i: Operator(self.measurement_basis[i]).to_matrix()
+            for i in range(len(self.measurement_basis))
+        }
+
     @classmethod
     def from_dict(cls, config_dict: Dict, machine: Optional[QuAM] = None):
         """
         Create a ShadowConfig object from a dictionary
         """
         qubits_names = config_dict["qubits"]
-        qubits = [machine.qubits[name] if machine is not None else name for name in qubits_names]
+        qubits = [
+            machine.qubits[name] if machine is not None else name
+            for name in qubits_names
+        ]
         config_dict["qubits"] = qubits
         config_dict["measurement_basis"] = QUAGateSet(config_dict["measurement_basis"])
         return cls(**config_dict)

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/shadow_config.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/experiments/classical_shadow/shadow_config.py
@@ -36,7 +36,6 @@ class ShadowConfig:
     measurement_basis: Optional[Dict[int, QuantumCircuit]] = None
     input_state_circuit_kwargs: Optional[Dict[str, Any]] = None
     readout_qubits: Optional[List[Transmon]] = None
-    target_qubits: Optional[List[Transmon]] = None
     readout_pulse_name: str = "readout"
     reset_method: Literal["active", "cooldown"] = "cooldown"
     reset_kwargs: Optional[Dict[str, Union[float, str, int]]] = field(


### PR DESCRIPTION
**Feel free to refuse this PR for it's include the line changes by my Python formatter.**

Also, this PR has merged with the fix at 

## Description

These are the fix by my own. Not just the error I mentioned in the following parts `Error Log`.

**There is a critical error in `Transmon` on call the attribution `_root`**, which seems to be replace by `.get_roots` in some version. This fix at commit 426e90e6cddd5059bcf02695061159cfdbd06ab4. If this fix commit is important for this project, it can be cherry-picked to create another PR to main branch. The respecting error log is at third parts

Also there is some modification on transpilation. I have made some modification by my own I thought it might be better and fully tested with QPU.
I added an extra step on transpilation, which it will transpile the input circuits with known basis gates, then goes to the transpilation with target. I found this can resolve the issues that some basis gates can be transpiled in orignal implementation.

## Error Log

### `ShadowConfig` Attribute Error

```log
/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam/components/channels.py:636: UserWarning: The 'thread' element argument is deprecated from qm.qua >= 1.2.2. Use 'core' instead.
  warnings.warn(
Traceback (most recent call last):
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.py", line 170, in <module>
    job = running_shadow_exp(shadow_exp, attempts=ATTEMPTS)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.py", line 99, in running_shadow_exp
    return classical_shadow_instance.run()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 200, in run
    cs_prog = self.cs_prog(simulate=simulate)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 147, in cs_prog
    qiskit_to_qua_macro(self.config.input_state_circuit(**self.config.input_state_circuit_kwargs), self.machine, self.config.target_qubits)
                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ShadowConfig' object has no attribute 'target_qubits'. Did you mean: 'readout_qubits'?
```

After adding `target_qubits` to `ShadowConfig`, the error was resolved.
But another error occurred:

### `KeyError: 'ry'` in Qiskit to QUA Macro Conversion

```log
/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam/components/channels.py:636: UserWarning: The 'thread' element argument is deprecated from qm.qua >= 1.2.2. Use 'core' instead.
  warnings.warn(
Error processing instruction: CircuitInstruction(operation=Instruction(name='ry', num_qubits=1, num_clbits=0, params=[0.0]), qubits=(<Qubit register=(2, "q"), index=1>,), clbits=())
Traceback (most recent call last):
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.py", line 170, in <module>
    job = running_shadow_exp(shadow_exp, attempts=ATTEMPTS)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.py", line 99, in running_shadow_exp
    return classical_shadow_instance.run()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 200, in run
    cs_prog = self.cs_prog(simulate=simulate)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 147, in cs_prog
    qiskit_to_qua_macro(self.config.input_state_circuit(**self.config.input_state_circuit_kwargs), self.machine, self.config.target_qubits)
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 74, in qiskit_to_qua_macro
    raise e
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 61, in qiskit_to_qua_macro
    result = qubit.apply(instruction.operation.name, *instruction.operation.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam/components/quantum_components/quantum_component.py", line 25, in apply
    operation_obj = self.get_macros()[operation]
                    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'ry'

```

### `Transmon` issues.

```log
/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam/components/channels.py:636: UserWarning: The 'thread' element argument is deprecated from qm.qua >= 1.2.2. Use 'core' instead.
  warnings.warn(
Error processing instruction: CircuitInstruction(operation=Instruction(name='cz', num_qubits=2, num_clbits=0, params=[]), qubits=(<Qubit register=(5, "q"), index=0>, <Qubit register=(5, "q"), index=1>), clbits=())
Traceback (most recent call last):
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.all_qiskit.py", line 170, in <module>
    job = running_shadow_exp(shadow_exp, attempts=ATTEMPTS)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/playground/classical_shadow_results/./cz_gate.all_qiskit.py", line 99, in running_shadow_exp
    return classical_shadow_instance.run()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 270, in run
    cs_prog = self.cs_prog(simulate=simulate)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 186, in cs_prog
    qiskit_to_qua_macro(
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 103, in qiskit_to_qua_macro
    raise e
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/experiments/classical_shadow/classical_shadow.py", line 80, in qiskit_to_qua_macro
    qubit_pair = qubit_control @ qubit_target
                 ~~~~~~~~~~~~~~^~~~~~~~~~~~~~
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam_libs/components/transmon.py", line 152, in __matmul__
    for qubit_pair in self._root.qubit_pairs.values():
                      ^^^^^^^^^^
  File "/home/nccu/Documents/.homejupyter/quam/quam_arena11/lib/python3.11/site-packages/quam/utils/reference_class.py", line 48, in __getattribute__
    attr_val = super().__getattribute__(attr)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Transmon' object has no attribute '_root'
```
