### PR TITLE
Merge qm_develop: calibration node improvements, GST, JAZZ ZZ, and simulation mode

### DIFF
--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
@@ -43,8 +43,8 @@ import numpy as np
 # %% {Node_parameters}
 class Parameters(NodeParameters):
 
-    qubits: Optional[List[str]] = ['q9']
-    num_averages: int = 1000
+    qubits: Optional[List[str]] = ['q1']
+    num_averages: int = 100
     operation: str = "saturation"
     operation_amplitude_factor: Optional[float] = 0.013 #0.004, 0.02 # q6:3e-3, q7:1e-2, q8:3e-3, q9:***,
     operation_len_in_ns: Optional[int] = None
@@ -255,21 +255,36 @@ if not node.parameters.simulate:
                 offset = q.z.joint_offset
             else:
                 offset = 0.0
-            print(f"flux offset for qubit {q.name} is {offset*1e3 + flux_shift.sel(qubit = q.name).values*1e3:.0f} mV")
-            print(f"(shift of  {flux_shift.sel(qubit = q.name).values*1e3:.0f} mV)")
+            quad_term = float(coeff.sel(degree=2, qubit=q.name))
+            flux_shift_q = float(flux_shift.sel(qubit=q.name).values)
+            drive_freq = float(freq_shift.sel(qubit=q.name).values)
+            sweetspot_freq = drive_freq + q.xy.RF_frequency
+            sweet_offset = offset + flux_shift_q
+            flux_phase_ratio = np.sqrt(-quad_term / sweetspot_freq * 4)
+            print(f"flux offset for qubit {q.name} is {offset*1e3 + flux_shift_q*1e3:.0f} mV")
+            print(f"(shift of  {flux_shift_q*1e3:.0f} mV)")
             print(
-                f"Drive frequency for {q.name} is {(freq_shift.sel(qubit = q.name).values + q.xy.RF_frequency)/1e9:.3f} GHz"
+                f"Drive frequency for {q.name} is {sweetspot_freq/1e9:.3f} GHz"
             )
-            print(f"(shift of {freq_shift.sel(qubit = q.name).values/1e6:.0f} MHz)")
-            print(f"quad term for qubit {q.name} is {float(coeff.sel(degree = 2, qubit = q.name)/1e9):.3e} GHz/V^2 \n")
-            fit_results[q.name]["flux_shift"] = float(flux_shift.sel(qubit=q.name).values)
-            fit_results[q.name]["drive_freq"] = float(freq_shift.sel(qubit=q.name).values)
-            fit_results[q.name]["quad_term"] = float(coeff.sel(degree=2, qubit=q.name))
+            print(f"(shift of {drive_freq/1e6:.0f} MHz)")
+            print(f"quad term for qubit {q.name} is {quad_term/1e9:.3e} GHz/V^2")
+            print(f"sweetspot_freq for {q.name} is {sweetspot_freq/1e9:.6f} GHz")
+            print(f"sweet_offset for {q.name} is {sweet_offset*1e3:.3f} mV")
+            print(f"flux/phase ratio for {q.name} is {flux_phase_ratio:.6e} \n")
+            fit_results[q.name]["flux_shift"] = flux_shift_q
+            fit_results[q.name]["drive_freq"] = drive_freq
+            fit_results[q.name]["quad_term"] = quad_term
+            fit_results[q.name]["sweetspot_freq"] = sweetspot_freq
+            fit_results[q.name]["sweet_offset"] = sweet_offset
+            fit_results[q.name]["flux_phase_ratio"] = flux_phase_ratio
         else:
             print(f"No fit for qubit {q.name}")
             fit_results[q.name]["flux_shift"] = np.nan
             fit_results[q.name]["drive_freq"] = np.nan
             fit_results[q.name]["quad_term"] = np.nan
+            fit_results[q.name]["sweetspot_freq"] = np.nan
+            fit_results[q.name]["sweet_offset"] = np.nan
+            fit_results[q.name]["flux_phase_ratio"] = np.nan
     node.results["fit_results"] = fit_results
 
     # %% {Plotting}
@@ -296,7 +311,6 @@ if not node.parameters.simulate:
     if node.parameters.load_data_id is None:
         with node.record_state_updates():
             for q in qubits:
-                # if q.name in ['q3', 'q5']:
                 if not np.isnan(flux_shift.sel(qubit=q.name).values):
                     if flux_point == "independent":
                         q.z.independent_offset += fit_results[q.name]["flux_shift"]
@@ -304,9 +318,12 @@ if not node.parameters.simulate:
                             q.z.joint_offset += fit_results[q.name]["flux_shift"]
                             q.z.independent_offset = q.z.joint_offset - q.phi0_voltage / 2 
                     elif flux_point == "joint":
-                        q.z.joint_offset += fit_results[q.name]["flux_shift"]
+                        q.z.joint_offset += fit_results[q.name]["flux_shift"] / 2
                     q.xy.intermediate_frequency += fit_results[q.name]["drive_freq"]
                     q.freq_vs_flux_01_quad_term = fit_results[q.name]["quad_term"]
+                    q.extras["sweetspot_freq"] = fit_results[q.name]["sweetspot_freq"]
+                    q.extras["sweet_offset"] = fit_results[q.name]["sweet_offset"]
+                    q.extras["flux_phase_ratio"] = fit_results[q.name]["flux_phase_ratio"]
 
     # %% {Save_results}
     node.results["ds"] = ds

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
@@ -318,7 +318,7 @@ if not node.parameters.simulate:
                             q.z.joint_offset += fit_results[q.name]["flux_shift"]
                             q.z.independent_offset = q.z.joint_offset - q.phi0_voltage / 2 
                     elif flux_point == "joint":
-                        q.z.joint_offset += fit_results[q.name]["flux_shift"] / 2
+                        q.z.joint_offset += fit_results[q.name]["flux_shift"]
                     q.xy.intermediate_frequency += fit_results[q.name]["drive_freq"]
                     q.freq_vs_flux_01_quad_term = fit_results[q.name]["quad_term"]
                     q.extras["sweetspot_freq"] = fit_results[q.name]["sweetspot_freq"]

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03b_qubit_spectroscopy_vs_flux.py
@@ -43,7 +43,7 @@ import numpy as np
 # %% {Node_parameters}
 class Parameters(NodeParameters):
 
-    qubits: Optional[List[str]] = ['q1']
+    qubits: Optional[List[str]] = None
     num_averages: int = 100
     operation: str = "saturation"
     operation_amplitude_factor: Optional[float] = 0.013 #0.004, 0.02 # q6:3e-3, q7:1e-2, q8:3e-3, q9:***,

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -132,12 +132,13 @@ with program() as multi_qubit_spec_vs_flux:
                 # Update the qubit frequency
                 qubit.xy.update_frequency(df + qubit.xy.intermediate_frequency)
                 with for_(*from_array(dc, dcs)):
-                    if node.parameters.reset_type == "active":
-                        # active_reset(qubit, "readout")
-                        active_reset_simple(qubit, "readout")
-                    else:
-                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                        qubit_pair.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            # active_reset(qubit, "readout")
+                            active_reset_simple(qubit, "readout")
+                        else:
+                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                            qubit_pair.align()
                     
                     if "coupler_qubit_crosstalk" in qubit_pair.extras:
                         assign(comp_flux_qubit, qubit_pair.extras["coupler_qubit_crosstalk"] * dc )

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03d_qubit_spectroscopy_vs_coupler_flux_pulse.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/03d_qubit_spectroscopy_vs_coupler_flux_pulse.py
@@ -131,12 +131,13 @@ with program() as multi_qubit_spec_vs_flux:
                 # Update the qubit frequency
                 qubit.xy.update_frequency(df + qubit.xy.intermediate_frequency)
                 with for_(*from_array(dc, dcs)):
-                    if node.parameters.reset_type == "active":
-                        # active_reset(qubit, "readout")
-                        active_reset_simple(qubit, "readout")
-                    else:
-                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                        qubit_pair.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            # active_reset(qubit, "readout")
+                            active_reset_simple(qubit, "readout")
+                        else:
+                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                            qubit_pair.align()
                     
                     if "coupler_qubit_crosstalk" in qubit_pair.extras:
                         assign(comp_flux_qubit, qubit_pair.extras["coupler_qubit_crosstalk"] * dc )

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/04_Power_Rabi.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/04_Power_Rabi.py
@@ -224,12 +224,12 @@ if not node.parameters.simulate:
             }
         )
     else:
-            load_data_id = node.parameters.load_data_id
-            node = node.load_from_id(load_data_id)
-            ds = node.results["ds"]
-            restore_load_data_id(node, load_data_id)
-            machine = node.machine
-            qubits = resolve_qubits_from_node(machine, node)
+        load_data_id = node.parameters.load_data_id
+        node = node.load_from_id(load_data_id)
+        ds = node.results["ds"]
+        restore_load_data_id(node, load_data_id)
+        machine = node.machine
+        qubits = resolve_qubits_from_node(machine, node)
     # Add the dataset to the node
     node.results = {"ds": ds}
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/04_Power_Rabi.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/04_Power_Rabi.py
@@ -120,12 +120,14 @@ with program() as power_rabi:
     npi = declare(int)  # QUA variable for the number of qubit pulses
     count = declare(int)  # QUA variable for counting the qubit pulses
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
+            qubit.z.settle()
         qubit.align()
 
         with for_(n, 0, n < n_avg, n + 1):
@@ -133,12 +135,11 @@ with program() as power_rabi:
             with for_(*from_array(npi, N_pi_vec)):
                 with for_(*from_array(a, amps)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset(qubit, "readout")
-                    else:
-                        if node.parameters.simulate: qubit.wait(16 * u.ns)
-                        # else: qubit.wait(qubit.thermalization_time * u.ns)
-                        else: qubit.wait(machine.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit, "readout")
+                        else:
+                            qubit.wait(machine.thermalization_time * u.ns)
 
                     # Loop for error amplification (perform many qubit pulses)
                     with for_(count, 0, count < npi, count + 1):
@@ -223,12 +224,12 @@ if not node.parameters.simulate:
             }
         )
     else:
-        load_data_id = node.parameters.load_data_id
-        node = node.load_from_id(load_data_id)
-        ds = node.results["ds"]
-        restore_load_data_id(node, load_data_id)
-        machine = node.machine
-        qubits = resolve_qubits_from_node(machine, node)
+            load_data_id = node.parameters.load_data_id
+            node = node.load_from_id(load_data_id)
+            ds = node.results["ds"]
+            restore_load_data_id(node, load_data_id)
+            machine = node.machine
+            qubits = resolve_qubits_from_node(machine, node)
     # Add the dataset to the node
     node.results = {"ds": ds}
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05_T1.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05_T1.py
@@ -99,24 +99,27 @@ with program() as t1:
         state = [declare(int) for _ in range(num_qubits)]
         state_st = [declare_stream() for _ in range(num_qubits)]
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
 
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
+            qubit.z.settle()
         qubit.align()
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
             with for_(*from_array(t, idle_times)):
-                if node.parameters.reset_type == "active":
-                    # active_reset(qubit, "readout")
-                    active_reset_simple(qubit, "readout")
-                else:
-                    qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                    qubit.align()
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        # active_reset(qubit, "readout")
+                        active_reset_simple(qubit, "readout")
+                    else:
+                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                        qubit.align()
 
                 qubit.xy.play("x180")
                 qubit.align()
@@ -194,12 +197,12 @@ if not node.parameters.simulate:
         ds = ds.assign_coords(idle_time=4 * ds.idle_time / u.us)  # convert to µs
         ds.idle_time.attrs = {"long_name": "idle time", "units": "µs"}
     else:
-        load_data_id = node.parameters.load_data_id
-        node = node.load_from_id(load_data_id)
-        ds = node.results["ds"]
-        restore_load_data_id(node, load_data_id)
-        machine = node.machine
-        qubits = resolve_qubits_from_node(machine, node)
+            load_data_id = node.parameters.load_data_id
+            node = node.load_from_id(load_data_id)
+            ds = node.results["ds"]
+            restore_load_data_id(node, load_data_id)
+            machine = node.machine
+            qubits = resolve_qubits_from_node(machine, node)
     # Add the dataset to the node
     node.results = {"ds": ds}
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05_T1.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05_T1.py
@@ -197,12 +197,12 @@ if not node.parameters.simulate:
         ds = ds.assign_coords(idle_time=4 * ds.idle_time / u.us)  # convert to µs
         ds.idle_time.attrs = {"long_name": "idle time", "units": "µs"}
     else:
-            load_data_id = node.parameters.load_data_id
-            node = node.load_from_id(load_data_id)
-            ds = node.results["ds"]
-            restore_load_data_id(node, load_data_id)
-            machine = node.machine
-            qubits = resolve_qubits_from_node(machine, node)
+        load_data_id = node.parameters.load_data_id
+        node = node.load_from_id(load_data_id)
+        ds = node.results["ds"]
+        restore_load_data_id(node, load_data_id)
+        machine = node.machine
+        qubits = resolve_qubits_from_node(machine, node)
     # Add the dataset to the node
     node.results = {"ds": ds}
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05b_T1_vs_coulper_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/05b_T1_vs_coulper_flux.py
@@ -149,13 +149,14 @@ with program() as t1_vs_coupler_flux:
             save(n, n_st)
             with for_(*from_array(flux_coupler, fluxes_coupler)):
                 with for_(*from_array(t, idle_times)):
-                    if node.parameters.reset_type == "active":
-                        # active_reset(qubit, "readout")
-                        active_reset_simple(qubit, "readout")
-                        qubit_pair.align()
-                    else:
-                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                        qubit_pair.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            # active_reset(qubit, "readout")
+                            active_reset_simple(qubit, "readout")
+                            qubit_pair.align()
+                        else:
+                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                            qubit_pair.align()
                     
                     if "coupler_qubit_crosstalk" in qubit_pair.extras:
                         assign(comp_flux_qubit, arb_flux_bias_offset [qubit.name] + qubit_pair.extras["coupler_qubit_crosstalk"] * flux_coupler )

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06_Ramsey.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06_Ramsey.py
@@ -92,8 +92,9 @@ with program() as ramsey:
         state_st = [declare_stream() for _ in range(num_qubits)]
 
     for multiplexed_qubits in qubits.batch():
-        for qubit in multiplexed_qubits.values():
-            machine.set_all_fluxes(flux_point, target=qubit)
+        if not node.parameters.simulate:
+            for qubit in multiplexed_qubits.values():
+                machine.set_all_fluxes(flux_point, target=qubit)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
@@ -108,10 +109,11 @@ with program() as ramsey:
                     align()
 
                     for i, qubit in multiplexed_qubits.items():
-                        if node.parameters.reset_type == "active":
-                            active_reset(qubit, "readout")
-                        else:
-                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                        if not node.parameters.simulate:
+                            if node.parameters.reset_type == "active":
+                                active_reset(qubit, "readout")
+                            else:
+                                qubit.resonator.wait(qubit.thermalization_time * u.ns)
                         reset_frame(qubit.xy.name)
                         qubit.align()
                         

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06b_T2_echo.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06b_T2_echo.py
@@ -84,29 +84,31 @@ with program() as t1:
     for i, qubit in enumerate(qubits):
 
         # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint" or "arbitrary":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint" or "arbitrary":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align()
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
             with for_(*from_array(t, idle_times)):
-                if node.parameters.reset_type == "active":
-                    active_reset(qubit, "readout")
-                else:
-                    qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                    qubit.align()
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        active_reset(qubit, "readout")
+                    else:
+                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                        qubit.align()
                 
                     
                 qubit.xy.play("x90")
@@ -221,7 +223,6 @@ if not node.parameters.simulate:
     for ax, qubit in grid_iter(grid):
         if node.parameters.use_state_discrimination:
             ds.sel(qubit = qubit['qubit']).state.plot(ax = ax)
-            
             ax.set_ylabel('State')
         else:
             ds.sel(qubit = qubit['qubit']).I.plot(ax = ax)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06c_T2_echo_vs_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06c_T2_echo_vs_coupler_flux.py
@@ -128,12 +128,13 @@ with program() as t2_echo_vs_coupler_flux:
             save(n, n_st)
             with for_(*from_array(flux_coupler, fluxes_coupler)):
                 with for_(*from_array(t, idle_times)):
-                    if node.parameters.reset_type == "active":
-                        active_reset(qubit, "readout")
-                        qubit_pair.align()
-                    else:
-                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                        qubit_pair.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qubit, "readout")
+                            qubit_pair.align()
+                        else:
+                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                            qubit_pair.align()
 
                     if "coupler_qubit_crosstalk" in qubit_pair.extras:
                         assign(

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06d_T2_echo_vs_qubit_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/06d_T2_echo_vs_qubit_flux.py
@@ -112,12 +112,13 @@ with program() as t2_echo_vs_coupler_flux:
             save(n, n_st)
             with for_(*from_array(flux_qubit, fluxes_qubit)):
                 with for_(*from_array(t, idle_times)):
-                    if node.parameters.reset_type == "active":
-                        active_reset(qubit, "readout")
-                        qubit.align()
-                    else:
-                        qubit.resonator.wait(qubit.thermalization_time * u.ns)
-                        qubit.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qubit, "readout")
+                            qubit.align()
+                        else:
+                            qubit.resonator.wait(qubit.thermalization_time * u.ns)
+                            qubit.align()
                     
                     if not node.parameters.use_qubit_flux_pulse:
                         qubit.z.set_dc_offset(flux_qubit)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07a_Readout_Frequency_Optimization.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07a_Readout_Frequency_Optimization.py
@@ -96,13 +96,15 @@ with program() as ro_freq_opt:
     Q_e_st = [declare_stream() for _ in range(num_qubits)]
     n_st = declare_stream()
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
 
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset)
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset)
+            qubit.z.settle()
         qubit.align()
 
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07b_IQ_Blobs.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07b_IQ_Blobs.py
@@ -92,7 +92,8 @@ with program() as iq_blobs:
     I_e, I_e_st, Q_e, Q_e_st, _, _ = qua_declaration(num_qubits=num_qubits)
 
     for multiplexed_qubits in qubits.batch():
-        machine.set_all_fluxes(flux_point=flux_point, target=list(multiplexed_qubits.values())[0])
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point=flux_point, target=list(multiplexed_qubits.values())[0])
 
         with for_(n, 0, n < n_runs, n + 1):
             save(n, n_st)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07c_Readout_Power_Optimization.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07c_Readout_Power_Optimization.py
@@ -97,13 +97,15 @@ with program() as iq_blobs:
     I_e, I_e_st, Q_e, Q_e_st, _, _ = qua_declaration(num_qubits=num_qubits)
     a = declare(fixed)
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
 
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
+            qubit.z.settle()
         qubit.align()
         # align() # True multiplexed       
 
@@ -111,12 +113,13 @@ with program() as iq_blobs:
             # ground iq blobs for all qubits
             save(n, n_st)
             with for_(*from_array(a, amps)):
-                if reset_type == "active":
-                    active_reset_simple(qubit, "readout")
-                elif reset_type == "thermal":
-                    qubit.wait(qubit.thermalization_time * u.ns)
-                else:
-                    raise ValueError(f"Unrecognized reset type {reset_type}.")
+                if not node.parameters.simulate:
+                    if reset_type == "active":
+                        active_reset_simple(qubit, "readout")
+                    elif reset_type == "thermal":
+                        qubit.wait(qubit.thermalization_time * u.ns)
+                    else:
+                        raise ValueError(f"Unrecognized reset type {reset_type}.")
 
                 qubit.align()
                 # align() # True multiplexed
@@ -127,12 +130,13 @@ with program() as iq_blobs:
                 save(I_g[i], I_g_st[i])
                 save(Q_g[i], Q_g_st[i])
 
-                if reset_type == "active":
-                    active_reset_simple(qubit, "readout")
-                elif reset_type == "thermal":
-                    qubit.wait(qubit.thermalization_time * u.ns)
-                else:
-                    raise ValueError(f"Unrecognized reset type {reset_type}.")
+                if not node.parameters.simulate:
+                    if reset_type == "active":
+                        active_reset_simple(qubit, "readout")
+                    elif reset_type == "thermal":
+                        qubit.wait(qubit.thermalization_time * u.ns)
+                    else:
+                        raise ValueError(f"Unrecognized reset type {reset_type}.")
                 qubit.align()
                 # align() # True multiplexed
                 qubit.xy.play("x180")

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07d_Readout_Frequency_Duration_Power_Optimization.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/07d_Readout_Frequency_Duration_Power_Optimization.py
@@ -133,7 +133,8 @@ def readout_optimization_3d_measured_in_batches(n_avg: int, measurement_batch: O
         n_st = declare_stream()
 
         for multiplexed_qubits in qubits.batch():
-            machine.set_all_fluxes(flux_point=flux_point, target=list(multiplexed_qubits.values())[0])
+            if not node.parameters.simulate:
+                machine.set_all_fluxes(flux_point=flux_point, target=list(multiplexed_qubits.values())[0])
 
             with for_(n, 0, n < n_avg, n + 1):
                 save(n, n_st)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08a_Qubit_Spectroscopy_E_to_F.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08a_Qubit_Spectroscopy_E_to_F.py
@@ -104,21 +104,23 @@ with program() as qubit_spec:
     I, I_st, Q, Q_st, n, n_st = qua_declaration(num_qubits=num_qubits)
     df = declare(int)  # QUA variable for the qubit frequency
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align()
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08a_Qubit_Spectroscopy_E_to_F_with_E_to_G.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08a_Qubit_Spectroscopy_E_to_F_with_E_to_G.py
@@ -104,21 +104,23 @@ with program() as qubit_spec:
     I, I_st, Q, Q_st, n, n_st = qua_declaration(num_qubits=num_qubits)
     df = declare(int)  # QUA variable for the qubit frequency
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align()
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08b_Power_Rabi_E_to_F.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08b_Power_Rabi_E_to_F.py
@@ -110,19 +110,20 @@ with program() as power_rabi:
     count = declare(int)  # QUA variable for counting the qubit pulses
 
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align()
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08c_Readout_Frequency_Optimization_G_E_F.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08c_Readout_Frequency_Optimization_G_E_F.py
@@ -104,19 +104,20 @@ with program() as ro_freq_opt:
 
     for i, qubit in enumerate(qubits):
 
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align()
 

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08d_IQ_Blobs_G_E_F.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08d_IQ_Blobs_G_E_F.py
@@ -116,8 +116,8 @@ with program() as iq_blobs:
 
     for i, qubit in enumerate(qubits):
 
-        # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qubit)
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qubit)
         wait(4)
         qubit.resonator.update_frequency(
             qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
@@ -130,16 +130,17 @@ with program() as iq_blobs:
             wait(4)
             update_frequency(qubit.xy.name, qubit.xy.intermediate_frequency)
             wait(4)
-            if reset_type == "active":
-                active_reset_gef(qubit)
-                qubit.resonator.update_frequency(
-                    qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
-                )
-                wait(4)
-            elif reset_type == "thermal":
-                wait(4 * qubit.thermalization_time * u.ns)
-            else:
-                raise ValueError(f"Unrecognized reset type {reset_type}.")
+            if not node.parameters.simulate:
+                if reset_type == "active":
+                    active_reset_gef(qubit)
+                    qubit.resonator.update_frequency(
+                        qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
+                    )
+                    wait(4)
+                elif reset_type == "thermal":
+                    wait(4 * qubit.thermalization_time * u.ns)
+                else:
+                    raise ValueError(f"Unrecognized reset type {reset_type}.")
 
             qubit.align()
             wait(4)
@@ -150,16 +151,17 @@ with program() as iq_blobs:
             save(I_g[i], I_g_st[i])
             save(Q_g[i], Q_g_st[i])
 
-            if reset_type == "active":
-                active_reset_gef(qubit)
-                qubit.resonator.update_frequency(
-                    qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
-                )
-                wait(4)
-            elif reset_type == "thermal":
-                wait(4*qubit.thermalization_time * u.ns)
-            else:
-                raise ValueError(f"Unrecognized reset type {reset_type}.")
+            if not node.parameters.simulate:
+                if reset_type == "active":
+                    active_reset_gef(qubit)
+                    qubit.resonator.update_frequency(
+                        qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
+                    )
+                    wait(4)
+                elif reset_type == "thermal":
+                    wait(4*qubit.thermalization_time * u.ns)
+                else:
+                    raise ValueError(f"Unrecognized reset type {reset_type}.")
             wait(4)
             qubit.align()
             wait(4)
@@ -173,16 +175,17 @@ with program() as iq_blobs:
             save(I_e[i], I_e_st[i])
             save(Q_e[i], Q_e_st[i])
 
-            if reset_type == "active":
-                active_reset_gef(qubit)
-                qubit.resonator.update_frequency(
-                    qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
-                )
-                wait(4)
-            elif reset_type == "thermal":
-                wait(4*qubit.thermalization_time * u.ns)
-            else:
-                raise ValueError(f"Unrecognized reset type {reset_type}.")
+            if not node.parameters.simulate:
+                if reset_type == "active":
+                    active_reset_gef(qubit)
+                    qubit.resonator.update_frequency(
+                        qubit.resonator.intermediate_frequency + qubit.resonator.GEF_frequency_shift
+                    )
+                    wait(4)
+                elif reset_type == "thermal":
+                    wait(4*qubit.thermalization_time * u.ns)
+                else:
+                    raise ValueError(f"Unrecognized reset type {reset_type}.")
             wait(4)
             qubit.align()
             wait(4)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08e_EF_RabiChevron.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08e_EF_RabiChevron.py
@@ -101,19 +101,20 @@ with program() as EF_PR_Chevron:
     dura_scal = declare(int)
 
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            machine.apply_all_couplers_to_min()
-            qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                machine.apply_all_couplers_to_min()
+                qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            qb.z.settle()
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                qb.z.settle()
 
         align()
 
@@ -125,10 +126,11 @@ with program() as EF_PR_Chevron:
                 with for_(*from_array(df, dfs)):
 
 
-                    if node.parameters.reset_type == 'thermal':
-                        wait(qubit.thermalization_time * u.ns)
-                    else:
-                        active_reset_gef(qubit)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == 'thermal':
+                            wait(qubit.thermalization_time * u.ns)
+                        else:
+                            active_reset_gef(qubit)
 
                     wait(4)
                     # Reset the qubit frequency

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08f_EF_PowerRabiState.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/08f_EF_PowerRabiState.py
@@ -102,14 +102,14 @@ with program() as EF_power_rabi_state:
     count = declare(int)  # QUA variable for counting the qubit pulses
 
     for i, qubit in enumerate(qubits):
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
-        qubit.z.settle()
-        qubit.align() 
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
+            qubit.z.settle()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align(*[q.xy.name for q in qubits] +
                [q.resonator.name for q in qubits] +
@@ -120,10 +120,11 @@ with program() as EF_power_rabi_state:
             with for_(*from_array(npi, N_pi_vec)):
                 with for_(*from_array(a, amps)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset_gef(qubit)
-                    else:
-                        qubit.wait(qubit.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset_gef(qubit)
+                        else:
+                            qubit.wait(qubit.thermalization_time * u.ns)
 
                     qubit.align()
                     qubit.xy.play('x180')

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09_Power_Rabi_State.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09_Power_Rabi_State.py
@@ -107,23 +107,15 @@ with program() as power_rabi:
     count = declare(int)  # QUA variable for counting the qubit pulses
 
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the minimum frequency point
-        # if flux_point == "independent":
-        #     machine.apply_all_flux_to_min()
-        #     machine.apply_all_couplers_to_min()
-        #     qubit.z.to_independent_idle()
-        # elif flux_point == "joint":
-        #     machine.apply_all_flux_to_joint_idle()
-        # else:
-        #     machine.apply_all_flux_to_zero()
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
-        qubit.z.settle()
-        qubit.align() 
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            if "c" in qubit.id: qubit.z.set_dc_offset(qubit.z.joint_offset) # for coupler-test case
+            qubit.z.settle()
 
-        # Wait for the flux bias to settle
-        for qb in qubits:
-            wait(1000, qb.z.name)
+            # Wait for the flux bias to settle
+            for qb in qubits:
+                wait(1000, qb.z.name)
 
         align(*[q.xy.name for q in qubits] +
                [q.resonator.name for q in qubits] +
@@ -134,10 +126,11 @@ with program() as power_rabi:
             with for_(*from_array(npi, N_pi_vec)):
                 with for_(*from_array(a, amps)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset(qubit)
-                    else:
-                        qubit.wait(qubit.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit)
+                        else:
+                            qubit.wait(qubit.thermalization_time * u.ns)
 
                     qubit.align()
                     # Loop for error amplification (perform many qubit pulses)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09_Power_Rabi_State.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09_Power_Rabi_State.py
@@ -50,6 +50,7 @@ class Parameters(NodeParameters):
     flux_point_joint_or_independent: Literal["joint", "independent"] = "independent"
     reset_type_thermal_or_active: Literal["thermal", "active"] = "thermal"
     simulate: bool = False
+    update_x90: bool = True
     timeout: int = 100
 
 
@@ -278,6 +279,8 @@ else:
     with node.record_state_updates():
         for q in qubits:
             q.xy.operations[operation].amplitude = fit_results[q.name]["Pi_amplitude"]
+            if operation == "x180" and node.parameters.update_x90:
+                q.xy.operations["x90"].amplitude = fit_results[q.name]["Pi_amplitude"] / 2
 
     # %% {Save_results}
     node.outcomes = {q.name: "successful" for q in qubits}

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09a_Stark_Detuning.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09a_Stark_Detuning.py
@@ -116,22 +116,25 @@ with program() as stark_detuning:
     count = declare(int)  # QUA variable for counting the qubit pulses
     iteration = declare(int)
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     assign(iteration, 0)
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            qubit.z.settle()
         qubit.align()
 
         with for_(n, 0, n < n_avg, n + 1):
             with for_(*from_array(npi, N_pi_vec)):
                 with for_(*from_array(df, dfs)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset(qubit)
-                    else:
-                        qubit.wait(qubit.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit)
+                        else:
+                            qubit.wait(qubit.thermalization_time * u.ns)
 
                     # Update the qubit frequency after initialization for active reset
                     update_frequency(qubit.xy.name, df + qubit.xy.intermediate_frequency)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09b_DRAG_Calibration_180_minus_180.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09b_DRAG_Calibration_180_minus_180.py
@@ -120,11 +120,13 @@ with program() as drag_calibration:
     npi = declare(int)  # QUA variable for the number of qubit pulses
     count = declare(int)  # QUA variable for counting the qubit pulses
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            qubit.z.settle()
         qubit.align()
 
         with for_(n, 0, n < n_avg, n + 1):
@@ -132,10 +134,11 @@ with program() as drag_calibration:
             with for_(*from_array(npi, N_pi_vec)):
                 with for_(*from_array(a, amps)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset_simple(qubit, "readout")
-                    else:
-                        qubit.wait(qubit.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset_simple(qubit, "readout")
+                        else:
+                            qubit.wait(qubit.thermalization_time * u.ns)
 
                     # Loop for error amplification (perform many qubit pulses)
                     with for_(count, 0, count < npi, count + 1):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09c_DRAG_Calibration_180_90.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/09c_DRAG_Calibration_180_90.py
@@ -108,11 +108,13 @@ with program() as drag_calibration:
     npi = declare(int)  # QUA variable for the number of qubit pulses
     count = declare(int)  # QUA variable for counting the qubit pulses
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     for i, qubit in enumerate(qubits):
-        # Bring the active qubits to the desired frequency point
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-        qubit.z.settle()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+            qubit.z.settle()
         qubit.align()
 
 
@@ -121,10 +123,11 @@ with program() as drag_calibration:
             for option in [0, 1]:
                 with for_(*from_array(a, amps)):
                     # Initialize the qubits
-                    if reset_type == "active":
-                        active_reset_simple(qubit, "readout")
-                    else:
-                        qubit.wait(machine.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset_simple(qubit, "readout")
+                        else:
+                            qubit.wait(machine.thermalization_time * u.ns)
 
                     if option == 0:
                         play("x180" * amp(1, 0, 0, a), qubit.xy.name)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/100_Gate_Set_Tomography.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/100_Gate_Set_Tomography.py
@@ -194,8 +194,9 @@ with program() as GST:
         with for_(single_germ_order, 0, single_germ_order < total_germs_num * max_germs_depth, single_germ_order + max_germs_depth):
             with for_(native_gate_order, 0, native_gate_order < max_germs_depth, native_gate_order + 1):
                 assign(single_germ_list[native_gate_order], tokenized_germs_list[single_germ_order + native_gate_order])
-                if reset_type == "active":
-                    active_reset(qubit)
+                if not node.parameters.simulate:
+                    if reset_type == "active":
+                        active_reset(qubit)
                 elif reset_type == "thermal":
                     qubit.wait(qubit.thermalization_time * u.ns)
                     

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/100a_Gate_Set_Tomography_AIS.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/100a_Gate_Set_Tomography_AIS.py
@@ -1,0 +1,522 @@
+"""
+    Gate Set Tomography (Advance Input Stream)
+    ==========================================
+    Variant of 100_Gate_Set_Tomography that streams germ sequences to the OPX via
+    ``advance_input_stream``, avoiding the OPX1000 static gate-table limit (~16000 ints).
+
+    Germ sequences are pushed from Python with ``job.push_to_input_stream`` once per
+    circuit while the QUA program repeats each circuit ``num_runs`` times before
+    advancing to the next. Only ``max_germs_depth`` ints live on the OPX at compile
+    time instead of ``total_germs_num * max_germs_depth``.
+"""
+# %% {Imports}
+import re
+import threading
+from typing import Literal, List, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pygsti
+import xarray as xr
+from pygsti.modelpacks import smq1Q_XYI as std
+from qm import SimulationConfig
+from qm.qua import *
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import fetching_tool, progress_counter
+from qualang_tools.units import unit
+from qualibrate import NodeParameters, QualibrationNode
+
+from quam_libs.components import QuAM, Transmon
+from quam_libs.lib.save_utils import fetch_results_as_xarray
+from quam_libs.macros import active_reset, qua_declaration, readout_state
+
+OPX1000_GATE_TABLE_LIMIT = 16000
+GERM_TOKENS_STREAM_NAME = "germ_tokens"
+
+# %% {Node_parameters}
+class Parameters(NodeParameters):
+
+    qubits: Optional[List[str]] = ["q1"]
+    max_circuit_depth_in_power: int = 9
+    num_runs: int = 100
+    reset_type_thermal_or_active: Literal["thermal", "active"] = "active"
+    flux_point_joint_or_independent: Literal["joint", "independent"] = "joint"
+    simulate: bool = False
+    simulation_duration_ns: int = 5000
+    timeout: int = 100
+    load_data_id: Optional[int] = None
+    multiplexed: bool = False
+
+node = QualibrationNode(name="100a_Gate_Set_Tomography_AIS", parameters=Parameters())
+
+# %% {Initialize_QuAM_and_QOP}
+u = unit(coerce_to_integer=True)
+machine = QuAM.load()
+node.machine = machine
+config = machine.generate_config()
+if node.parameters.load_data_id is None:
+    qmm = machine.connect()
+
+if node.parameters.qubits is None or node.parameters.qubits == "":
+    qubits = machine.active_qubits
+else:
+    qubits = [machine.qubits[q] for q in node.parameters.qubits]
+num_qubits = len(qubits)
+
+# %% {QUA_program_parameters}
+max_circuit_length = [
+    2**i for i in range(max(node.parameters.max_circuit_depth_in_power, 0) + 1)
+]
+n_runs = node.parameters.num_runs
+flux_point = node.parameters.flux_point_joint_or_independent
+reset_type = node.parameters.reset_type_thermal_or_active
+
+# %% {Utility functions}
+def parse_gst_circuit_string(circuit_str):
+    """Parse a pyGSTi circuit string into a list of pulse labels."""
+    clean_str = circuit_str.split()[0]
+    clean_str = clean_str.replace("@(0)", "")
+    clean_str = clean_str.replace("({})", "(I)")
+    clean_str = clean_str.replace("{}", "(I)")
+    clean_str = clean_str.replace("([])", "(I)")
+
+    token_map = {
+        "Gxpi2:0": "X",
+        "Gypi2:0": "Y",
+        "I": "I",
+    }
+    temp_str = clean_str
+    for key, token in token_map.items():
+        temp_str = temp_str.replace(key, token)
+
+    while "^" in temp_str:
+        def expand_match(match):
+            content = match.group(1)
+            power = int(match.group(2))
+            return content * power
+
+        temp_str = re.sub(r"\(([^)]+)\)\^(\d+)", expand_match, temp_str)
+
+    temp_str = temp_str.replace("(", "").replace(")", "")
+
+    final_map = {
+        "X": "x90",
+        "Y": "y90",
+        "I": "I",
+    }
+    return [final_map[ch] for ch in temp_str if ch in final_map]
+
+
+def tokenize_gst_circuits(gst_str):
+    """Convert GST circuit strings into tokenized format for QUA execution."""
+    gate_set_token = {
+        "I": 0,
+        "x90": 1,
+        "y90": 2,
+        "x180": 3,
+        "y180": 4,
+    }
+    gate_set_length_list = [len(g) for g in gst_str]
+    max_gate_set_length = max(gate_set_length_list)
+    tokenized_circuits = []
+
+    for germ in gst_str:
+        g_len = len(germ)
+        tokenized = [gate_set_token[g] for g in germ]
+        if g_len < max_gate_set_length:
+            tokenized.extend([-1] * (max_gate_set_length - g_len))
+        tokenized_circuits.append(tokenized)
+
+    return tokenized_circuits, gate_set_length_list
+
+
+def play_tokenized_gst_circuits(tokenized_germ, depth, qubit: Transmon):
+    i = declare(int)
+    with for_(i, 0, i < depth, i + 1):
+        with switch_(tokenized_germ[i], unsafe=True):
+            with case_(0):
+                qubit.xy.wait(4)
+            with case_(1):
+                qubit.xy.play("x90")
+            with case_(2):
+                qubit.xy.play("y90")
+            with case_(3):
+                qubit.xy.play("x180")
+            with case_(4):
+                qubit.xy.play("y180")
+            with case_(-1):
+                pass
+
+
+def push_gst_germs_to_input_stream(job, tokenized_germs):
+    """Push each germ sequence once; QUA repeats it num_runs times before advancing."""
+    total_pushes = len(tokenized_germs)
+    for push_count, tokens in enumerate(tokenized_germs, start=1):
+        job.push_to_input_stream(GERM_TOKENS_STREAM_NAME, tokens)
+        if push_count % 100 == 0 or push_count == total_pushes:
+            print(f"Input stream: pushed {push_count}/{total_pushes} germ sequences")
+
+
+def start_push_gst_germs_in_background(job, tokenized_germs):
+    thread = threading.Thread(
+        target=push_gst_germs_to_input_stream,
+        args=(job, tokenized_germs),
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def fetch_gst_state_averaged(handles, qubit, total_germs_num, n_runs):
+    """Fetch 2D results (germs x runs) and average over runs per circuit."""
+    try:
+        ds = fetch_results_as_xarray(
+            handles,
+            [qubit],
+            {"runs": np.arange(n_runs), "germs": np.arange(total_germs_num)},
+        )
+        if "runs" in ds.dims and "germs" in ds.dims:
+            return ds.mean(dim="runs")
+    except ValueError:
+        pass
+
+    flat = np.array(handles.get("state1").fetch_all(), dtype=float).ravel()
+    if flat.size == total_germs_num:
+        return xr.Dataset(
+            {"state": (("qubit", "germs"), flat.reshape(1, -1))},
+            coords={"qubit": [qubit.name], "germs": np.arange(total_germs_num)},
+        )
+    if flat.size == n_runs:
+        raise ValueError(
+            f"Got {n_runs} values (one per run, not per circuit). The compiled QUA "
+            "program likely still has runs as the outer loop. Re-run the QUA program "
+            "cell so the loop order is: outer germs, inner runs."
+        )
+    raise ValueError(
+        f"Expected shape ({total_germs_num}, {n_runs}) from "
+        f"buffer({n_runs}).buffer({total_germs_num}), got {flat.size} values. "
+        "Re-run the QUA program cell after code changes."
+    )
+
+
+# %% Setup the GST model
+std_model = std.target_model()
+exp_design = pygsti.protocols.StandardGSTDesign(
+    std_model,
+    std.prep_fiducials(),
+    std.meas_fiducials(),
+    std.germs(),
+    max_circuit_length,
+)
+
+all_germs_from_gst_model = [s.str for s in exp_design.all_circuits_needing_data]
+all_germs_to_qua_labels = [parse_gst_circuit_string(s) for s in all_germs_from_gst_model]
+all_germs_to_qua_tokenized_labels, all_germs_depth = tokenize_gst_circuits(all_germs_to_qua_labels)
+max_germs_depth = max(all_germs_depth)
+total_germs_num = len(all_germs_to_qua_tokenized_labels)
+static_gate_table_size = total_germs_num * max_germs_depth
+
+print("=== GST experiment design summary ===")
+print(f"max_circuit_length passed to pyGSTi: {max_circuit_length}")
+print(f"Longest germ sequence (max_germs_depth): {max_germs_depth}")
+print(f"Total number of gate lists (circuits/germs): {total_germs_num}")
+print(
+    f"Static gate-table size if compiled inline: "
+    f"{total_germs_num} x {max_germs_depth} = {static_gate_table_size}"
+)
+print(f"OPX1000 gate-table limit: {OPX1000_GATE_TABLE_LIMIT}")
+if static_gate_table_size > OPX1000_GATE_TABLE_LIMIT:
+    print(
+        f"Static table EXCEEDS limit by {static_gate_table_size - OPX1000_GATE_TABLE_LIMIT}; "
+        "this node streams germs via advance_input_stream."
+    )
+else:
+    print("Static table fits in OPX memory; AIS still used to avoid future depth scaling issues.")
+print(f"Input stream pushes (one per circuit): {total_germs_num}")
+print(f"Stream processing: buffer({n_runs}).buffer({total_germs_num})  [inner=runs, outer=germs]")
+print(
+    f"Total measurements: {n_runs} runs x {total_germs_num} germs = "
+    f"{n_runs * total_germs_num}"
+)
+print("=====================================")
+
+qubit = qubits[0]
+
+# %% {QUA_program}
+if node.parameters.simulate:
+    # Simulation does not support input streams reliably; use static gate table.
+    with program() as GST:
+        I, I_st, Q, Q_st, n, n_st = qua_declaration(num_qubits=1)
+        state = [declare(int) for _ in range(1)]
+        state_st = [declare_stream() for _ in range(1)]
+
+        single_germ_order = declare(int)
+        native_gate_order = declare(int)
+        tokenized_germs_list = declare(
+            int, value=np.array(all_germs_to_qua_tokenized_labels).flatten()
+        )
+        single_germ_list = declare(int, size=max_germs_depth)
+        germ_idx = declare(int)
+
+        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+
+        with for_(germ_idx, 0, germ_idx < total_germs_num, germ_idx + 1):
+            save(germ_idx, n_st)
+            assign(single_germ_order, germ_idx * max_germs_depth)
+            with for_(
+                native_gate_order, 0, native_gate_order < max_germs_depth, native_gate_order + 1
+            ):
+                assign(
+                    single_germ_list[native_gate_order],
+                    tokenized_germs_list[single_germ_order + native_gate_order],
+                )
+            with for_(n, 0, n < n_runs, n + 1):
+                if reset_type == "active":
+                    active_reset(qubit)
+                elif reset_type == "thermal":
+                    qubit.wait(qubit.thermalization_time * u.ns)
+                play_tokenized_gst_circuits(
+                    single_germ_list, depth=max_germs_depth, qubit=qubit
+                )
+                align()
+                readout_state(qubit, state[0])
+                save(state[0], state_st[0])
+
+        if not node.parameters.multiplexed:
+            align()
+
+        with stream_processing():
+            n_st.save("n")
+            state_st[0].buffer(n_runs).buffer(total_germs_num).save("state1")
+else:
+    with program() as GST:
+        I, I_st, Q, Q_st, n, n_st = qua_declaration(num_qubits=1)
+        state = [declare(int) for _ in range(1)]
+        state_st = [declare_stream() for _ in range(1)]
+
+        germ_idx = declare(int)
+        germ_tokens_is = declare_input_stream(
+            int, name=GERM_TOKENS_STREAM_NAME, size=max_germs_depth
+        )
+
+        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+
+        with for_(germ_idx, 0, germ_idx < total_germs_num, germ_idx + 1):
+            save(germ_idx, n_st)
+            advance_input_stream(germ_tokens_is)
+            with for_(n, 0, n < n_runs, n + 1):
+                if reset_type == "active":
+                    active_reset(qubit)
+                elif reset_type == "thermal":
+                    qubit.wait(qubit.thermalization_time * u.ns)
+                play_tokenized_gst_circuits(
+                    germ_tokens_is, depth=max_germs_depth, qubit=qubit
+                )
+                align()
+                readout_state(qubit, state[0])
+                save(state[0], state_st[0])
+
+        if not node.parameters.multiplexed:
+            align()
+
+        with stream_processing():
+            n_st.save("n")
+            state_st[0].buffer(n_runs).buffer(total_germs_num).save("state1")
+
+# %% {Simulate_or_execute}
+job = None
+
+if node.parameters.simulate:
+    simulation_config = SimulationConfig(
+        duration=node.parameters.simulation_duration_ns * 4
+    )
+    job = qmm.simulate(config, GST, simulation_config)
+    samples = job.get_simulated_samples()
+    waveform_report = job.get_simulated_waveform_report()
+    waveform_report.create_plot(samples, plot=True, save_path="./")
+    node.results = {"figure": plt.gcf()}
+    node.save()
+
+elif node.parameters.load_data_id is None:
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        job = qm.execute(GST)
+        push_thread = start_push_gst_germs_in_background(
+            job, all_germs_to_qua_tokenized_labels
+        )
+        results = fetching_tool(job, ["n"], mode="live")
+        while results.is_processing():
+            germ_idx = results.fetch_all()[0]
+            progress_counter(germ_idx, total_germs_num, start_time=results.start_time)
+        push_thread.join()
+        job.result_handles.wait_for_all_values()
+
+# %% {Data_fetching_and_dataset_creation}
+if not node.parameters.simulate:
+    if node.parameters.load_data_id is None:
+        ds = None
+        for i in range(num_qubits):
+            ds_ = fetch_gst_state_averaged(
+                job.result_handles, qubits[i], total_germs_num, n_runs
+            )
+            ds = xr.concat([ds, ds_], dim="qubit") if ds is not None else ds_
+        count1 = (ds.state.values * 100).astype(int)
+        count0 = 100 - count1
+        ds["count0"] = (("qubit", "germs"), count0)
+        ds["count1"] = (("qubit", "germs"), count1)
+    else:
+        node = node.load_from_id(node.parameters.load_data_id)
+        ds = node.results["ds"]
+
+    # %% {Data_analysis}
+
+    def transform_dataset_to_gst(ds):
+        gst_ds = pygsti.data.DataSet(outcome_labels=["0", "1"])
+        for i, crc in enumerate(exp_design.all_circuits_needing_data):
+            gst_ds.add_count_dict(
+                crc, {"0": ds.count0.values[0, i], "1": ds.count1.values[0, i]}
+            )
+        return gst_ds
+
+    node.results = {"ds": ds, "figs": {}, "results": {}}
+    node.results["ds"] = ds
+
+    gst_ds = transform_dataset_to_gst(ds)
+    gst_data = pygsti.protocols.ProtocolData(exp_design, gst_ds)
+    gst_protocol = pygsti.protocols.StandardGST()
+    gst_results = gst_protocol.run(gst_data, disable_checkpointing=True)
+
+    node.results["results"][qubit.name] = {}
+    node.results["results"][qubit.name]["gst_results"] = {
+        "TP": {
+            "rho0": {"density_mx": None, "fidelity": None},
+            "meas_op": {
+                "0": {"povm": None, "fidelity": None},
+                "1": {"povm": None, "fidelity": None},
+            },
+            "gate_op": {
+                "I": {"choi": None, "fidelity": None, "robustness": None},
+                "x90": {"choi": None, "fidelity": None, "robustness": None},
+                "y90": {"choi": None, "fidelity": None, "robustness": None},
+            },
+        },
+        "CPTP": {
+            "rho0": {"density_mx": None, "fidelity": None},
+            "meas_op": {
+                "0": {"povm": None, "fidelity": None},
+                "1": {"povm": None, "fidelity": None},
+            },
+            "gate_op": {
+                "I": {"choi": None, "fidelity": None, "robustness": None},
+                "x90": {"choi": None, "fidelity": None, "robustness": None},
+                "y90": {"choi": None, "fidelity": None, "robustness": None},
+            },
+        },
+        "Ideal": {
+            "rho0": {"density_mx": None, "fidelity": None},
+            "meas_op": {
+                "0": {"povm": None, "fidelity": None},
+                "1": {"povm": None, "fidelity": None},
+            },
+            "gate_op": {
+                "I": {"choi": None, "fidelity": None, "robustness": None},
+                "x90": {"choi": None, "fidelity": None, "robustness": None},
+                "y90": {"choi": None, "fidelity": None, "robustness": None},
+            },
+        },
+    }
+    estimate_keys = ["full TP", "CPTPLND", "Target"]
+    native_gate_keys = [(), ("Gxpi2", 0), ("Gypi2", 0)]
+    np.set_printoptions(suppress=True, precision=6)
+    for i, cond in enumerate(node.results["results"][qubit.name]["gst_results"].keys()):
+        est_model = gst_results.estimates[estimate_keys[i]].models["stdgaugeopt"]
+        print(f"\n=== Under {cond} condiction ===")
+
+        rho_vec = est_model.preps["rho0"]
+        rho_est_mat = pygsti.tools.vec_to_stdmx(rho_vec, basis="pp")
+        rho_std_mat = pygsti.tools.vec_to_stdmx(std_model.preps["rho0"], basis="pp")
+        state_fidelity = pygsti.tools.fidelity(rho_est_mat, rho_std_mat)
+        print(f"State preparation fidelity for '0' state is {state_fidelity:.6f}.")
+
+        node.results["results"][qubit.name]["gst_results"][cond]["rho0"]["density_mx"] = rho_est_mat
+        node.results["results"][qubit.name]["gst_results"][cond]["rho0"]["fidelity"] = state_fidelity
+
+        povm_obj = est_model.povms["Mdefault"]
+        print("State measurement fidelity for ", end="")
+        for label, effect_vec in povm_obj.items():
+            matrix_est_form = pygsti.tools.vec_to_stdmx(effect_vec, basis="pp")
+            matri_std_form = pygsti.tools.vec_to_stdmx(
+                std_model.povms["Mdefault"][str(label)], basis="pp"
+            )
+            meas_fidelity = pygsti.tools.fidelity(matrix_est_form, matri_std_form)
+            print(f"'{label}' state is {meas_fidelity:.6f} ", end="")
+
+            node.results["results"][qubit.name]["gst_results"][cond]["meas_op"][str(label)][
+                "povm"
+            ] = matrix_est_form
+            node.results["results"][qubit.name]["gst_results"][cond]["meas_op"][str(label)][
+                "fidelity"
+            ] = meas_fidelity
+
+        for j, gate in enumerate(
+            node.results["results"][qubit.name]["gst_results"][cond]["gate_op"].keys()
+        ):
+            matrix_ptm = est_model.operations[native_gate_keys[j]].to_dense()
+            choi = pygsti.tools.jamiolkowski.jamiolkowski_iso(
+                matrix_ptm, op_mx_basis="pp", choi_mx_basis="std"
+            )
+            infidelity = pygsti.tools.entanglement_infidelity(
+                matrix_ptm,
+                std_model.operations[native_gate_keys[j]].to_dense(),
+                "pp",
+            )
+            node.results["results"][qubit.name]["gst_results"][cond]["gate_op"][gate]["choi"] = choi
+            node.results["results"][qubit.name]["gst_results"][cond]["gate_op"][gate][
+                "fidelity"
+            ] = 1 - infidelity
+
+            print(f"\nGate Infidelity: {infidelity:.6f}")
+            evals = np.linalg.eigvals(choi)
+            print(f"Choi Eigenvalues: {np.round(evals.real, 6)}")
+
+    # %% {Update_state}
+    if node.parameters.reset_type_thermal_or_active == "active":
+        for i, j in zip(machine.active_qubit_names, "abcde"):
+            machine.qubits[i].xy.core = j
+            machine.qubits[i].resonator.core = j
+
+    # %% {Save_results}
+    if not node.parameters.simulate:
+        from pathlib import Path
+
+        from qualibrate_config.resolvers import get_qualibrate_config, get_qualibrate_config_path
+        from quam_libs.compat import get_node_dir_path
+
+        node.outcomes = {q.name: "successful" for q in qubits}
+        node.results["initial_parameters"] = node.parameters.model_dump()
+        gst_report_dirname = f"gst_report_{qubit.name}"
+        node.results["gst_report_dir"] = gst_report_dirname
+        node.results["gst_report_main"] = f"{gst_report_dirname}/main.html"
+        node.save()
+
+        qs = get_qualibrate_config(get_qualibrate_config_path())
+        node_dir = Path(get_node_dir_path(node.snapshot_idx, qs.storage.location))
+        gst_report_dir = node_dir / gst_report_dirname
+
+        try:
+            report = pygsti.report.construct_standard_report(
+                gst_results,
+                title=f"GST Report - {qubit.name}",
+            )
+            report.write_html(str(gst_report_dir), auto_open=False)
+            main_html = gst_report_dir / "main.html"
+            if not main_html.exists():
+                raise RuntimeError("pyGSTi finished without creating main.html")
+            print(f"GST HTML report saved to {main_html}")
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to generate GST HTML report. "
+                "pyGSTi requires plotly<6 for HTML reports; run `uv sync` to install a compatible plotly version."
+            ) from exc
+
+# %%
+

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/12_all_xy.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/12_all_xy.py
@@ -250,18 +250,20 @@ with program() as all_xy:
     state = [declare(int) for _ in range(num_qubits)]
     state_st = [declare_stream() for _ in range(num_qubits)]
 
-    machine.apply_all_couplers_to_min()
+    if not node.parameters.simulate:
+        machine.apply_all_couplers_to_min()
     assign(iteration, 0)
 
     for multiplexed_qubits in qubits.batch():
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            for qubit in multiplexed_qubits.values():
-                qubit.z.to_independent_idle()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            raise ValueError(f"Unrecognized flux point {flux_point}.")
+        if not node.parameters.simulate:
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                for qubit in multiplexed_qubits.values():
+                    qubit.z.to_independent_idle()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                raise ValueError(f"Unrecognized flux point {flux_point}.")
 
         align(
             *(
@@ -274,12 +276,13 @@ with program() as all_xy:
         with for_(n, 0, n < n_avg, n + 1):
             with for_(*from_array(sequence_index, sequence_indices)):
                 for qubit in multiplexed_qubits.values():
-                    if reset_type == "active":
-                        active_reset(qubit)
-                    elif reset_type == "thermal":
-                        qubit.wait(qubit.thermalization_time * u.ns)
-                    else:
-                        raise ValueError(f"Unrecognized reset type {reset_type}.")
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit)
+                        elif reset_type == "thermal":
+                            qubit.wait(qubit.thermalization_time * u.ns)
+                        else:
+                            raise ValueError(f"Unrecognized reset type {reset_type}.")
 
                 align(
                     *(

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/14x_xyz_delay.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/14x_xyz_delay.py
@@ -178,9 +178,9 @@ with program() as qua_prog:
     npi = declare(int)  # QUA variable for the number of qubit pulses
     count = declare(int)  # QUA variable for counting the qubit pulses
    
-    # Initialize the QPU in terms of flux points (flux tunable transmons and/or tunable couplers)
-    for qubit in qubits:
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+    if not node.parameters.simulate:
+        for qubit in qubits:
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
     align()
 
     # --- Batch over qubits (allows time-multiplexed execution respecting hardware constraints)
@@ -196,12 +196,13 @@ with program() as qua_prog:
                 with for_(segment, 0, segment < number_of_segments, segment + 1):
 
                     # 1. Reset qubits to ground state
-                    if reset_type == "active":
-                        active_reset(qubit)
-                    elif reset_type == "thermal":
-                        qubit.wait(4 * qubit.thermalization_time * u.ns)
-                    else:
-                        raise ValueError(f"Unrecognized reset type {reset_type}.")
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit)
+                        elif reset_type == "thermal":
+                            qubit.wait(4 * qubit.thermalization_time * u.ns)
+                        else:
+                            raise ValueError(f"Unrecognized reset type {reset_type}.")
 
                     # 2. State preparation: excited (x180) or ground (wait same duration)
                     if init_state == "e":

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/14y_xyz_delay_coupler.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/14y_xyz_delay_coupler.py
@@ -201,15 +201,15 @@ with program() as qua_prog:
     npi = declare(int)  # QUA variable for the number of qubit pulses
     count = declare(int)  # QUA variable for counting the qubit pulses
    
-    # Initialize the QPU in terms of flux points (flux tunable transmons and/or tunable couplers)
-    for qubit in qubits:
-        machine.set_all_fluxes(flux_point=flux_point, target=qubit)
-    align()
-    if reset_coupler_bias:
-        coupler.set_dc_offset(0.0)
-    else:
-        coupler.to_decouple_idle()
-    wait(1000)
+    if not node.parameters.simulate:
+        for qubit in qubits:
+            machine.set_all_fluxes(flux_point=flux_point, target=qubit)
+        align()
+        if reset_coupler_bias:
+            coupler.set_dc_offset(0.0)
+        else:
+            coupler.to_decouple_idle()
+        wait(1000)
 
     # --- Batch over qubits (allows time-multiplexed execution respecting hardware constraints)
     for i, qubit in enumerate(qubits):
@@ -224,12 +224,13 @@ with program() as qua_prog:
                 with for_(segment, 0, segment < number_of_segments, segment + 1):
 
                     # 1. Reset qubits to ground state
-                    if reset_type == "active":
-                        active_reset(qubit)
-                    elif reset_type == "thermal":
-                        qubit.wait(4 * qubit.thermalization_time * u.ns)
-                    else:
-                        raise ValueError(f"Unrecognized reset type {reset_type}.")
+                    if not node.parameters.simulate:
+                        if reset_type == "active":
+                            active_reset(qubit)
+                        elif reset_type == "thermal":
+                            qubit.wait(4 * qubit.thermalization_time * u.ns)
+                        else:
+                            raise ValueError(f"Unrecognized reset type {reset_type}.")
 
                     # 2. State preparation: excited (x180) or ground (wait same duration)
                     if init_state == "e":

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/16a_pi_vs_flux_long_distortions.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/16a_pi_vs_flux_long_distortions.py
@@ -186,10 +186,11 @@ with program() as qua_prog:
                 # Time delay loop
                 with for_each_(t_delay, times):
                     
-                    if node.parameters.reset_type_active_or_thermal == "active":
-                        active_reset(qubit)
-                    else:
-                        qubit.wait(qubit.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type_active_or_thermal == "active":
+                            active_reset(qubit)
+                        else:
+                            qubit.wait(qubit.thermalization_time * u.ns)
                    
                     if node.parameters.thermal_reset_extra_time_in_us:
                         qubit.wait(node.parameters.thermal_reset_extra_time_in_us * u.us)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/16b_cryoscope_short_distortions.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/16b_cryoscope_short_distortions.py
@@ -227,12 +227,13 @@ with program() as qua_prog:
             # Loop over the phase of the second ramsey x90 pulse to reconstruct the qubit phase
             with for_each_(frame, frames):
                 # Qubit initialization
-                if reset_type == "active":
-                    active_reset(qubit)
-                elif reset_type == "thermal":
-                    qubit.wait(qubit.thermalization_time * u.ns)
-                else:
-                    raise ValueError(f"Unrecognized reset type {reset_type}.")
+                if not node.parameters.simulate:
+                    if reset_type == "active":
+                        active_reset(qubit)
+                    elif reset_type == "thermal":
+                        qubit.wait(qubit.thermalization_time * u.ns)
+                    else:
+                        raise ValueError(f"Unrecognized reset type {reset_type}.")
                 
                 align()
                 ################################################################################################

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/17_crosstalk_spectroscopy_vs_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/17_crosstalk_spectroscopy_vs_flux.py
@@ -229,12 +229,13 @@ with program() as crosstalk_vs_flux:
                         # Update the qubit frequency
                         target_qubit.xy.update_frequency(df + target_qubit.xy.intermediate_frequency + expected_frequency_offset, keep_phase=True)
                         # Wait for the qubits to decay to the ground state
-                        if reset_type == "active":
-                            active_reset(qubit, "readout")
-                        else:
-                            if node.parameters.simulate: qubit.wait(16 * u.ns)
-                            # else: qubit.wait(qubit.thermalization_time * u.ns)
-                            else: qubit.wait(machine.thermalization_time * u.ns)
+                        if not node.parameters.simulate:
+                            if reset_type == "active":
+                                active_reset(qubit, "readout")
+                            else:
+                                if node.parameters.simulate: qubit.wait(16 * u.ns)
+                                # else: qubit.wait(qubit.thermalization_time * u.ns)
+                                else: qubit.wait(machine.thermalization_time * u.ns)
                         # Flux sweeping for a qubit
                         duration = (
                             operation_len * u.ns

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32a_Cz_phase_calibration_frame.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32a_Cz_phase_calibration_frame.py
@@ -66,7 +66,7 @@ class Parameters(NodeParameters):
     num_averages: int = 100
     flux_point_joint_or_independent: Literal["joint", "independent"] = "joint"
     reset_type: Literal['active', 'thermal'] = "active"
-    simulate: bool = False
+    simulate: bool = True
     timeout: int = 100
     amp_range : float = 0.08
     amp_step : float = 0.002
@@ -148,17 +148,18 @@ with program() as CPhase_Oscillations:
 
     
     for i, qp in enumerate(qubit_pairs):
-        qp.gates[operation_name].phase_shift_control = 0.0
-        qp.gates[operation_name].phase_shift_target = 0.0
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            # qp.apply_mutual_flux_point()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            qp.gates[operation_name].phase_shift_control = 0.0
+            qp.gates[operation_name].phase_shift_target = 0.0
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                # qp.apply_mutual_flux_point()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)         
@@ -166,13 +167,14 @@ with program() as CPhase_Oscillations:
                 with for_(*from_array(frame, frames)):
                     with for_(*from_array(control_initial, [0,1])):
                         # reset
-                        if node.parameters.reset_type == "active":
-                            active_reset_gef(qp.qubit_control)
-                            active_reset(qp.qubit_target)
-                            # active_reset_simple(qp.qubit_control)
-                            # active_reset_simple(qp.qubit_target)
-                        else:
-                            wait(qp.qubit_control.thermalization_time * u.ns)
+                        if not node.parameters.simulate:
+                            if node.parameters.reset_type == "active":
+                                active_reset_gef(qp.qubit_control)
+                                active_reset(qp.qubit_target)
+                                # active_reset_simple(qp.qubit_control)
+                                # active_reset_simple(qp.qubit_target)
+                            else:
+                                wait(qp.qubit_control.thermalization_time * u.ns)
                         qp.align()
                         reset_frame(qp.qubit_target.xy.name)
                         reset_frame(qp.qubit_control.xy.name)                   

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32a_Cz_phase_calibration_frame.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32a_Cz_phase_calibration_frame.py
@@ -66,7 +66,7 @@ class Parameters(NodeParameters):
     num_averages: int = 100
     flux_point_joint_or_independent: Literal["joint", "independent"] = "joint"
     reset_type: Literal['active', 'thermal'] = "active"
-    simulate: bool = True
+    simulate: bool = False
     timeout: int = 100
     amp_range : float = 0.08
     amp_step : float = 0.002

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32bx_cz_phase_coupler_error_amp.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32bx_cz_phase_coupler_error_amp.py
@@ -135,15 +135,16 @@ with program() as CPhase_Oscillations:
     count = declare(int)
     
     for i, qp in enumerate(qubit_pairs):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            # qp.apply_mutual_flux_point()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                # qp.apply_mutual_flux_point()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)         
@@ -152,13 +153,14 @@ with program() as CPhase_Oscillations:
                     with for_(*from_array(control_initial, [0,1])):
                         with for_(*from_array(n_repeats, repeats)):
                             # reset
-                            if node.parameters.reset_type == "active":
-                                active_reset_simple(qp.qubit_control)
-                                qp.align()
-                                active_reset_simple(qp.qubit_target)
-                                qp.align()
-                            else:
-                                wait(qp.qubit_control.thermalization_time * u.ns)
+                            if not node.parameters.simulate:
+                                if node.parameters.reset_type == "active":
+                                    active_reset_simple(qp.qubit_control)
+                                    qp.align()
+                                    active_reset_simple(qp.qubit_target)
+                                    qp.align()
+                                else:
+                                    wait(qp.qubit_control.thermalization_time * u.ns)
                             qp.align()
                             reset_frame(qp.qubit_target.xy.name)
                             reset_frame(qp.qubit_control.xy.name)                   

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32x_cz_conditional_phase_error_amp.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/32x_cz_conditional_phase_error_amp.py
@@ -173,7 +173,8 @@ with program() as CZ_phase_calibration_error_amp:
     for i, qp in enumerate(qubit_pairs):
         qp.gates[operation_name].phase_shift_control = 0.0
         qp.gates[operation_name].phase_shift_target = 0.0
-        machine.set_all_fluxes(flux_point, qp)
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
             with for_(n_op, 1, n_op <= num_operations, n_op + 1):
@@ -181,11 +182,12 @@ with program() as CZ_phase_calibration_error_amp:
                     with for_(*from_array(frame, frames)):
                         with for_(*from_array(control_initial, [0, 1])):
                                 # Reset and align both qubits
-                                if node.parameters.reset_type == "active":
-                                    active_reset_gef(qp.qubit_control)
-                                    active_reset(qp.qubit_target)
-                                else:
-                                    wait(qp.qubit_control.thermalization_time * u.ns)
+                                if not node.parameters.simulate:
+                                    if node.parameters.reset_type == "active":
+                                        active_reset_gef(qp.qubit_control)
+                                        active_reset(qp.qubit_target)
+                                    else:
+                                        wait(qp.qubit_control.thermalization_time * u.ns)
                                 qp.align()
                                 reset_frame(qp.qubit_target.xy.name)
                                 reset_frame(qp.qubit_control.xy.name)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/33a_Cz_1Qphase_calibration_frame.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/33a_Cz_1Qphase_calibration_frame.py
@@ -143,30 +143,32 @@ with program() as CPhase_Oscillations:
     state_st_target = [declare_stream() for _ in range(num_qubit_pairs)]
     
     for i, qp in enumerate(qubit_pairs):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            # qp.apply_mutual_flux_point()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                # qp.apply_mutual_flux_point()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)         
             with for_(*from_array(frame, frames)):
                 for qubit, state_q, state_st in [(qp.qubit_control, state_control[i], state_st_control[i]), (qp.qubit_target, state_target[i], state_st_target[i])]:
                     # reset
-                    if node.parameters.reset_type == "active":
-                        active_reset(qp.qubit_control)
-                        qp.align()
-                        active_reset(qp.qubit_target)
-                        qp.align()
-                        # active_reset_simple(qp.qubit_control)
-                        # active_reset_simple(qp.qubit_target)
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qp.qubit_control)
+                            qp.align()
+                            active_reset(qp.qubit_target)
+                            qp.align()
+                            # active_reset_simple(qp.qubit_control)
+                            # active_reset_simple(qp.qubit_target)
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
                     qp.align()
                     # setting both qubits ot the initial state
                     qubit.xy.play("x90")

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/33b_Cz_1Qphase_calibration_frame_error_amp.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/33b_Cz_1Qphase_calibration_frame_error_amp.py
@@ -269,14 +269,15 @@ with program() as CZ_1Q_phase_error_amp:
     extra_phase_t = declare(fixed)
 
     for i, qp in enumerate(qubit_pairs):
-        # Bring the active qubits to the desired frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            # Bring the active qubits to the desired frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
@@ -305,13 +306,14 @@ with program() as CZ_1Q_phase_error_amp:
                         ),
                     ]:
                         # Initialize both qubits before each Ramsey trace.
-                        if reset_type == "active":
-                            active_reset(qp.qubit_control)
-                            qp.align()
-                            active_reset(qp.qubit_target)
-                            qp.align()
-                        else:
-                            wait(qp.qubit_control.thermalization_time * u.ns)
+                        if not node.parameters.simulate:
+                            if reset_type == "active":
+                                active_reset(qp.qubit_control)
+                                qp.align()
+                                active_reset(qp.qubit_target)
+                                qp.align()
+                            else:
+                                wait(qp.qubit_control.thermalization_time * u.ns)
                         qp.align()
                         reset_frame(qp.qubit_control.xy.name)
                         reset_frame(qp.qubit_target.xy.name)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/34_2Q_confusion_matrix.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/34_2Q_confusion_matrix.py
@@ -126,31 +126,33 @@ with program() as CPhase_Oscillations:
     state_st = [declare_stream() for _ in range(num_qubit_pairs)]
     
     for i, qp in enumerate(qubit_pairs):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            # qp.apply_mutual_flux_point()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                # qp.apply_mutual_flux_point()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st)         
             with for_(*from_array(control_initial, [0,1])):
                 with for_(*from_array(target_initial, [0,1])):
                     # reset
-                    if node.parameters.reset_type == "active":
-                            active_reset(qp.qubit_control)
-                            active_reset(qp.qubit_target)
-                            # wait(2*qp.qubit_control.thermalization_time * u.ns)
-                            # active_reset_simple(qp.qubit_control)
-                            # active_reset_simple(qp.qubit_target)
-                            # active_reset_simple(qp.qubit_control)
-                            # active_reset_simple(qp.qubit_target)                            
-                    else:
-                        wait(5*qp.qubit_control.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                                active_reset(qp.qubit_control)
+                                active_reset(qp.qubit_target)
+                                # wait(2*qp.qubit_control.thermalization_time * u.ns)
+                                # active_reset_simple(qp.qubit_control)
+                                # active_reset_simple(qp.qubit_target)
+                                # active_reset_simple(qp.qubit_control)
+                                # active_reset_simple(qp.qubit_target)                            
+                        else:
+                            wait(5*qp.qubit_control.thermalization_time * u.ns)
                     qp.align()
                     
                     # setting both qubits ot the initial state

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40a_Bell_state_Zbasis.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40a_Bell_state_Zbasis.py
@@ -137,16 +137,16 @@ with program() as CPhase_Oscillations:
             # reset
             if not node.parameters.simulate:
                 if node.parameters.reset_type == "active":
-                    # active_reset(qp.qubit_control)
-                    # active_reset(qp.qubit_target)
+                    active_reset(qp.qubit_control)
+                    active_reset(qp.qubit_target)
                     # qp.align()
-                    wait(2*qp.qubit_control.thermalization_time * u.ns)
-                    active_reset_simple(qp.qubit_control)
-                    active_reset_simple(qp.qubit_target)
-                    active_reset_simple(qp.qubit_control)
-                    active_reset_simple(qp.qubit_target)                       
-            else:
-                wait(16 * u.ns)
+                    # wait(2*qp.qubit_control.thermalization_time * u.ns)
+                    # active_reset_simple(qp.qubit_control)
+                    # active_reset_simple(qp.qubit_target)
+                    # active_reset_simple(qp.qubit_control)
+                    # active_reset_simple(qp.qubit_target)                       
+                else:
+                    wait(5*qp.qubit_control.thermalization_time * u.ns)
             qp.align()
             # Bell state
             if node.parameters.circuit == "BELL1":

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40a_Bell_state_Zbasis.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40a_Bell_state_Zbasis.py
@@ -135,7 +135,8 @@ with program() as CPhase_Oscillations:
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st)         
             # reset
-            if node.parameters.reset_type == "active":
+            if not node.parameters.simulate:
+                if node.parameters.reset_type == "active":
                     # active_reset(qp.qubit_control)
                     # active_reset(qp.qubit_target)
                     # qp.align()
@@ -145,10 +146,7 @@ with program() as CPhase_Oscillations:
                     active_reset_simple(qp.qubit_control)
                     active_reset_simple(qp.qubit_target)                       
             else:
-                if not node.parameters.simulate:
-                    wait(5*qp.qubit_control.thermalization_time * u.ns)
-                else:
-                    wait(16 * u.ns)
+                wait(16 * u.ns)
             qp.align()
             # Bell state
             if node.parameters.circuit == "BELL1":

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40b_Bell_state_tomography.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40b_Bell_state_tomography.py
@@ -298,8 +298,8 @@ with program() as CPhase_Oscillations:
     # tomo_axis_target = declare(int)
     
     for i, qp in enumerate(qubit_pairs):
-        # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qp.qubit_control)
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp.qubit_control)
 
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st) 
@@ -308,14 +308,15 @@ with program() as CPhase_Oscillations:
             for tomo_axis_control in [0,1,2]:
                 for tomo_axis_target in [0,1,2]:
                     # reset
-                    if node.parameters.reset_type == "active":
-                            # wait(2*qp.qubit_control.thermalization_time * u.ns)
-                            # active_reset_simple(qp.qubit_control)
-                            # active_reset_simple(qp.qubit_target)
-                            active_reset(qp.qubit_control)
-                            active_reset(qp.qubit_target)   
-                    else:
-                        wait(5*qp.qubit_control.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                                # wait(2*qp.qubit_control.thermalization_time * u.ns)
+                                # active_reset_simple(qp.qubit_control)
+                                # active_reset_simple(qp.qubit_target)
+                                active_reset(qp.qubit_control)
+                                active_reset(qp.qubit_target)   
+                        else:
+                            wait(5*qp.qubit_control.thermalization_time * u.ns)
                     qp.align()
                     # Bell state
                     qp.qubit_control.xy.play("-y90")

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40d_Confusion_matrix_general.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/40d_Confusion_matrix_general.py
@@ -153,23 +153,25 @@ with program() as ConfusionMatrixNQ:
     state_st = [declare_stream() for _ in range(num_qubit_groups)]
 
     for i, qg in enumerate(qubit_groups):
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
+            wait(1000)
 
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st)
 
             with nested_binary_loops(init_vars):
-                if node.parameters.reset_type == "active":
-                    for q in qg.qubits:
-                        active_reset(q)
-                else:
-                    wait(5 * qg.max_thermalization_time * u.ns)
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        for q in qg.qubits:
+                            active_reset(q)
+                    else:
+                        wait(5 * qg.max_thermalization_time * u.ns)
                 align()
 
                 for idx, q in enumerate(qg.qubits):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/41a_GHZ_Zbasi_least_squares.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/41a_GHZ_Zbasi_least_squares.py
@@ -158,25 +158,28 @@ with program() as GHZ_Zbasis_least_squares:
     state = [declare(int) for _ in range(num_qubit_groups)]
     state_st = [declare_stream() for _ in range(num_qubit_groups)]
     
-    if flux_point == "joint":
-        # Bring the active qubits to the desired frequency point
-        machine.apply_all_flux_to_joint_idle()
-    wait(1000)
+    if not node.parameters.simulate:
+        if flux_point == "joint":
+            # Bring the active qubits to the desired frequency point
+            machine.apply_all_flux_to_joint_idle()
+        wait(1000)
     
     for i, qg in enumerate(qubit_groups_for_qua):
-        # Bring the active qubits to the minimum frequency point
-        if flux_point != "joint":
-            machine.apply_all_flux_to_min()
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            if flux_point != "joint":
+                machine.apply_all_flux_to_min()
         align()
         
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st)         
             # reset
-            if node.parameters.reset_type == "active":
-                for q in qg.qubits:
-                    active_reset(q)
-            else:
-                wait(5 * qg.max_thermalization_time * u.ns)
+            if not node.parameters.simulate:
+                if node.parameters.reset_type == "active":
+                    for q in qg.qubits:
+                        active_reset(q)
+                else:
+                    wait(5 * qg.max_thermalization_time * u.ns)
             align()
             
             # GHZ chain preparation generalized for 3-5 qubits.

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/41b_GHZ_tomography.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/41b_GHZ_tomography.py
@@ -200,18 +200,20 @@ with program() as GHZ_tomography:
     tomo_axes = [declare(int) for _ in range(num_qubits)]
 
     for i, qg in enumerate(qubit_groups_for_qua):
-        # Bring the active qubits to the minimum frequency point
-        machine.apply_all_flux_to_joint_idle()
-        wait(1000)
+        if not node.parameters.simulate:
+            # Bring the active qubits to the minimum frequency point
+            machine.apply_all_flux_to_joint_idle()
+            wait(1000)
 
         with for_(n, 0, n < n_shots, n + 1):
             save(n, n_st)
             with nested_tomo_loops(tomo_axes):
-                if node.parameters.reset_type == "active":
-                    for q in qg.qubits:
-                        active_reset(q)
-                else:
-                    wait(5 * qg.max_thermalization_time * u.ns)
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        for q in qg.qubits:
+                            active_reset(q)
+                    else:
+                        wait(5 * qg.max_thermalization_time * u.ns)
                 align()
 
                 # GHZ state preparation for any number of qubits >= 2.

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50a_three_tone_coupler_spectroscopy_dc_offset.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50a_three_tone_coupler_spectroscopy_dc_offset.py
@@ -159,14 +159,15 @@ with program() as multi_res_spec_vs_flux:
                 qubit_control = qp.qubit_control
                 qubit_target = qp.qubit_target
 
-                if node.parameters.reset_type == "active":
-                    active_reset_simple(qubit_control)
-                    active_reset_simple(qubit_target)
-                    qp.align()
-                else:
-                    qubit_control.wait(qubit_control.thermalization_time * u.ns)
-                    qubit_target.wait(qubit_target.thermalization_time * u.ns)
-                    qp.align()
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        active_reset_simple(qubit_control)
+                        active_reset_simple(qubit_target)
+                        qp.align()
+                    else:
+                        qubit_control.wait(qubit_control.thermalization_time * u.ns)
+                        qubit_target.wait(qubit_target.thermalization_time * u.ns)
+                        qp.align()
 
                 # update the frequency of the control qubit to couler drive frequency
                 qubit_control.xy.update_frequency(df + coupler_IFs[qp.name])

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50b_three_tone_coupler_spectroscopy_flux_pulse.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50b_three_tone_coupler_spectroscopy_flux_pulse.py
@@ -195,14 +195,15 @@ with program() as multi_res_spec_vs_flux:
 
                 # Update the qubit frequency
                 qubit_control.xy.update_frequency(qubit_control.xy.intermediate_frequency)
-                if node.parameters.reset_type == "active":
-                    active_reset_simple(qubit_control)
-                    active_reset_simple(qubit_target)
-                    qp.align()
-                else:
-                    qubit_control.reset_qubit_thermal()
-                    qubit_target.reset_qubit_thermal()
-                    qp.align()
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        active_reset_simple(qubit_control)
+                        active_reset_simple(qubit_target)
+                        qp.align()
+                    else:
+                        qubit_control.reset_qubit_thermal()
+                        qubit_target.reset_qubit_thermal()
+                        qp.align()
 
                 # update the frequency of the control qubit to couler drive frequency
                 qubit_control.xy.update_frequency(df + coupler_IFs[qp.name])

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50c_three_tone_coupler_spectroscopy_vs_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50c_three_tone_coupler_spectroscopy_vs_coupler_flux.py
@@ -172,14 +172,15 @@ with program() as multi_res_spec_vs_flux:
                     qubit_control = qp.qubit_control
                     qubit_target = qp.qubit_target
                     
-                    if node.parameters.reset_type == "active":
-                        active_reset_simple(qubit_control)
-                        active_reset_simple(qubit_target)
-                        qp.align()
-                    else:
-                        qubit_control.wait(qubit_control.thermalization_time * u.ns)
-                        qubit_target.wait(qubit_target.thermalization_time * u.ns)
-                        qp.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset_simple(qubit_control)
+                            active_reset_simple(qubit_target)
+                            qp.align()
+                        else:
+                            qubit_control.wait(qubit_control.thermalization_time * u.ns)
+                            qubit_target.wait(qubit_target.thermalization_time * u.ns)
+                            qp.align()
 
                     # update the frequency of the control qubit to couler drive frequency
                     qubit_control.xy.update_frequency(df + coupler_IFs[qp.name])

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50d_three_tone_spectroscopy_coupler_Rabi.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50d_three_tone_spectroscopy_coupler_Rabi.py
@@ -140,14 +140,15 @@ with program() as multi_res_spec_vs_flux:
                 qubit_target = qp.qubit_target
 
                 # Update the qubit frequency
-                if node.parameters.reset_type == "active":
-                    active_reset_simple(qubit_control)
-                    active_reset_simple(qubit_target)
+                if not node.parameters.simulate:
+                    if node.parameters.reset_type == "active":
+                        active_reset_simple(qubit_control)
+                        active_reset_simple(qubit_target)
 
-                else:
-                    qubit_control.wait(qubit_control.thermalization_time * u.ns)
-                    qubit_target.wait(qubit_target.thermalization_time * u.ns)
-                    qp.align()
+                    else:
+                        qubit_control.wait(qubit_control.thermalization_time * u.ns)
+                        qubit_target.wait(qubit_target.thermalization_time * u.ns)
+                        qp.align()
 
                 # update the frequency of the control qubit to couler drive frequency
                 qubit_control.xy.update_frequency(coupler_IFs[qp.name])

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50e_three_tone_coupler_long_crysocope.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/50e_three_tone_coupler_long_crysocope.py
@@ -189,15 +189,16 @@ with program() as multi_res_spec_vs_flux:
                     # Update the qubit frequency
                     # qubit_control.xy.update_frequency(qubit_control.xy.intermediate_frequency)
                     
-                    if node.parameters.reset_type == "active":
-                        active_reset_simple(qubit_control)
-                        active_reset_simple(qubit_target)
-                        qp.align()
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset_simple(qubit_control)
+                            active_reset_simple(qubit_target)
+                            qp.align()
 
-                    else:
-                        qubit_control.wait(qubit_control.thermalization_time * u.ns)
-                        qubit_target.wait(qubit_target.thermalization_time * u.ns)
-                        qp.align()
+                        else:
+                            qubit_control.wait(qubit_control.thermalization_time * u.ns)
+                            qubit_target.wait(qubit_target.thermalization_time * u.ns)
+                            qp.align()
 
                     if node.parameters.wait_extra_time:
                         qubit_control.xy.wait(node.parameters.duration_in_ns // 4)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61_coupler_zeropoint_calibrationy.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61_coupler_zeropoint_calibrationy.py
@@ -231,13 +231,14 @@ with program() as coupler_zero_point_calibration:
             with for_each_(flux_coupler, fluxes_coupler_qp[qp.name]):
                 with for_each_(flux_qubit, fluxes_qp[qp.name]):
                     # reset
-                    if node.parameters.reset_type == "active":
-                        active_reset(qp.qubit_control)
-                        active_reset(qp.qubit_target)
-                        qp.align()
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
-                        wait(qp.qubit_target.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qp.qubit_control)
+                            active_reset(qp.qubit_target)
+                            qp.align()
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
+                            wait(qp.qubit_target.thermalization_time * u.ns)
                     align()
                     if "coupler_qubit_crosstalk" in qp.extras:
                         assign(comp_flux_qubit, flux_qubit + qp.extras["coupler_qubit_crosstalk"] * flux_coupler)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61x_coupler_zeropoint_calibration_advanced_fitting.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61x_coupler_zeropoint_calibration_advanced_fitting.py
@@ -241,13 +241,14 @@ with program() as coupler_zero_point_calibration:
             with for_each_(flux_coupler, fluxes_coupler_qp[qp.name]):
                 with for_each_(flux_qubit, fluxes_qp[qp.name]):
                     # reset
-                    if node.parameters.reset_type == "active":
-                        active_reset(qp.qubit_control)
-                        active_reset(qp.qubit_target)
-                        qp.align()
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
-                        wait(qp.qubit_target.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qp.qubit_control)
+                            active_reset(qp.qubit_target)
+                            qp.align()
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
+                            wait(qp.qubit_target.thermalization_time * u.ns)
                     align()
                     if "coupler_qubit_crosstalk" in qp.extras:
                         assign(comp_flux_qubit, flux_qubit + qp.extras["coupler_qubit_crosstalk"] * flux_coupler)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61y_qubit_coupler_flux_leakage_phase_calibration.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/61y_qubit_coupler_flux_leakage_phase_calibration.py
@@ -127,13 +127,14 @@ with program() as coupler_leakage_phase_calibration:
             with for_(*from_array(amp_coupler, coupler_amp_scales)):
                 with for_(*from_array(amp_qubit, qubit_amp_scales)):
                     # --- Leakage measurement ---
-                    if node.parameters.reset_type == "active":
-                        active_reset(qp.qubit_control)
-                        active_reset(qp.qubit_target)
-                        qp.align()
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
-                        wait(qp.qubit_target.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qp.qubit_control)
+                            active_reset(qp.qubit_target)
+                            qp.align()
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
+                            wait(qp.qubit_target.thermalization_time * u.ns)
                     align()
                     qp.qubit_control.xy.play("x180")
                     qp.qubit_target.xy.play("x180")
@@ -152,13 +153,14 @@ with program() as coupler_leakage_phase_calibration:
                     # --- Phase measurement (Ramsey-style) ---
                     with for_(*from_array(frame, frames)):
                         with for_(*from_array(control_initial, [0, 1])):
-                            if node.parameters.reset_type == "active":
-                                active_reset(qp.qubit_control)
-                                active_reset(qp.qubit_target)
-                                qp.align()
-                            else:
-                                wait(qp.qubit_control.thermalization_time * u.ns)
-                                wait(qp.qubit_target.thermalization_time * u.ns)
+                            if not node.parameters.simulate:
+                                if node.parameters.reset_type == "active":
+                                    active_reset(qp.qubit_control)
+                                    active_reset(qp.qubit_target)
+                                    qp.align()
+                                else:
+                                    wait(qp.qubit_control.thermalization_time * u.ns)
+                                    wait(qp.qubit_target.thermalization_time * u.ns)
                             qp.align()
                             reset_frame(qp.qubit_target.xy.name)
                             reset_frame(qp.qubit_control.xy.name)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62_coupler_interaction strength calibration.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62_coupler_interaction strength calibration.py
@@ -173,13 +173,14 @@ with program() as CPhase_Oscillations:
             with for_(*from_array(flux_coupler, fluxes_coupler)):
                 with for_(*from_array(idle_time, idle_times)):
                     # reset
-                    if node.parameters.reset_type == "active":
-                            active_reset_simple(qp.qubit_control)
-                            active_reset_simple(qp.qubit_target)
-                            qp.align()
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
-                        wait(qp.qubit_target.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                                active_reset_simple(qp.qubit_control)
+                                active_reset_simple(qp.qubit_target)
+                                qp.align()
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
+                            wait(qp.qubit_target.thermalization_time * u.ns)
                     
                     
                     if "coupler_qubit_crosstalk" in qp.extras:

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62c_11_leakage_vs_qubit_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62c_11_leakage_vs_qubit_coupler_flux.py
@@ -169,14 +169,15 @@ with program() as CPhase_Oscillations:
             with for_(*from_array(flux_coupler_amp, flux_coupler_amplitudes)):
                 with for_(*from_array(flux_qubit_amp, flux_qubit_amplitudes)):
                         # reset
-                        if node.parameters.reset_type == "active":
-                            # active_reset(qp.qubit_control)
-                            # active_reset(qp.qubit_target)
-                            active_reset_gef(qp.qubit_control)
-                            active_reset_gef(qp.qubit_target)
-                        else:
-                            wait(qp.qubit_control.thermalization_time * u.ns)
-                            wait(qp.qubit_target.thermalization_time * u.ns)
+                        if not node.parameters.simulate:
+                            if node.parameters.reset_type == "active":
+                                # active_reset(qp.qubit_control)
+                                # active_reset(qp.qubit_target)
+                                active_reset_gef(qp.qubit_control)
+                                active_reset_gef(qp.qubit_target)
+                            else:
+                                wait(qp.qubit_control.thermalization_time * u.ns)
+                                wait(qp.qubit_target.thermalization_time * u.ns)
 
                         # state preparation
                         qp.qubit_control.xy.play("x180")

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62d_11_leakage_amplification.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62d_11_leakage_amplification.py
@@ -150,10 +150,10 @@ with program() as leakage_amplification:
         qp.gates[operation_name].phase_shift_control = 0.0
         qp.gates[operation_name].phase_shift_target = 0.0
         # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qp)
-        if reset_coupler_bias:
-            qp.coupler.set_dc_offset(0.0)
         if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
+            if reset_coupler_bias:
+                qp.coupler.set_dc_offset(0.0)
             wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62d_11_leakage_amplification.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/62d_11_leakage_amplification.py
@@ -153,19 +153,21 @@ with program() as leakage_amplification:
         machine.set_all_fluxes(flux_point, qp)
         if reset_coupler_bias:
             qp.coupler.set_dc_offset(0.0)
-        wait(1000)
+        if not node.parameters.simulate:
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
             with for_(n_op, 1, n_op <= num_operations, n_op + 1):         
                 with for_(*from_array(flux_coupler_amp, flux_coupler_amplitudes)):
                             # reset
-                            if node.parameters.reset_type == "active":
-                                active_reset_gef(qp.qubit_control)
-                                active_reset_gef(qp.qubit_target)
-                            else:
-                                wait(qp.qubit_control.thermalization_time * u.ns)
-                                wait(qp.qubit_target.thermalization_time * u.ns)
+                            if not node.parameters.simulate:
+                                if node.parameters.reset_type == "active":
+                                    active_reset_gef(qp.qubit_control)
+                                    active_reset_gef(qp.qubit_target)
+                                else:
+                                    wait(qp.qubit_control.thermalization_time * u.ns)
+                                    wait(qp.qubit_target.thermalization_time * u.ns)
 
                             # state preparation
                             qp.qubit_control.xy.play("x180")

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/64c_Cz_phase_f_leakage_vs_qubit_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/64c_Cz_phase_f_leakage_vs_qubit_coupler_flux.py
@@ -172,14 +172,14 @@ with program() as CPhase_Oscillations:
         qp.gates["Cz"].phase_shift_control = 0.0
         qp.gates["Cz"].phase_shift_target = 0.0
         # Bring the active qubits to the minimum frequency point
-        if flux_point == "independent":
-            machine.apply_all_flux_to_min()
-            # qp.apply_mutual_flux_point()
-        elif flux_point == "joint":
-            machine.apply_all_flux_to_joint_idle()
-        else:
-            machine.apply_all_flux_to_zero()
         if not node.parameters.simulate:
+            if flux_point == "independent":
+                machine.apply_all_flux_to_min()
+                # qp.apply_mutual_flux_point()
+            elif flux_point == "joint":
+                machine.apply_all_flux_to_joint_idle()
+            else:
+                machine.apply_all_flux_to_zero()
             wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/64c_Cz_phase_f_leakage_vs_qubit_coupler_flux.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/64c_Cz_phase_f_leakage_vs_qubit_coupler_flux.py
@@ -179,7 +179,8 @@ with program() as CPhase_Oscillations:
             machine.apply_all_flux_to_joint_idle()
         else:
             machine.apply_all_flux_to_zero()
-        wait(1000)
+        if not node.parameters.simulate:
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
@@ -188,13 +189,14 @@ with program() as CPhase_Oscillations:
                     with for_(*from_array(frame, frames)):
                         with for_(*from_array(control_initial, [0, 1])):
                             # reset
-                            if node.parameters.reset_type == "active":
-                                active_reset_gef(qp.qubit_control)
-                                active_reset(qp.qubit_target)
-                                # active_reset_simple(qp.qubit_control)
-                                # active_reset_simple(qp.qubit_target)
-                            else:
-                                wait(qp.qubit_control.thermalization_time * u.ns)
+                            if not node.parameters.simulate:
+                                if node.parameters.reset_type == "active":
+                                    active_reset_gef(qp.qubit_control)
+                                    active_reset(qp.qubit_target)
+                                    # active_reset_simple(qp.qubit_control)
+                                    # active_reset_simple(qp.qubit_target)
+                                else:
+                                    wait(qp.qubit_control.thermalization_time * u.ns)
                             qp.align()
                             if "coupler_qubit_crosstalk" in qp.extras:
                                 assign(comp_flux_qubit, flux_qubit + qp.extras["coupler_qubit_crosstalk"] * flux_coupler)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/65a_02_11_oscillations_4nS.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/65a_02_11_oscillations_4nS.py
@@ -167,7 +167,8 @@ with program() as CPhase_Oscillations:
     
     for i, qp in enumerate(qubit_pairs):
         # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qp)
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
         assign(comp_flux_coupler, gate_refs[qp.name]["coupler_amplitude"])
         assign(comp_flux_qubit, gate_refs[qp.name]["qubit_amplitude"])
         with for_(n, 0, n < n_avg, n + 1):
@@ -177,12 +178,13 @@ with program() as CPhase_Oscillations:
                 # rest of the pulse
                 with for_(*from_array(t, times_cycles)):
                     # reset                    
-                    if node.parameters.reset_type == "active":
-                        active_reset_simple(qp.qubit_control)
-                        active_reset_simple(qp.qubit_target)
-                        qp.align()
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset_simple(qp.qubit_control)
+                            active_reset_simple(qp.qubit_target)
+                            qp.align()
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
 
                     # set both qubits to the excited state
                     for state,qubit in zip([state_control, state_target], [qp.qubit_control, qp.qubit_target]):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67a_Ramsey_ZZ_coupling.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67a_Ramsey_ZZ_coupling.py
@@ -169,7 +169,8 @@ with program() as Ramsey_ZZ_coupling:
         machine.set_all_fluxes(flux_point, qp)
         if reset_coupler_bias:
             qp.coupler.set_dc_offset(0.0)
-        wait(1000)
+        if not node.parameters.simulate:
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67a_Ramsey_ZZ_coupling.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67a_Ramsey_ZZ_coupling.py
@@ -166,10 +166,11 @@ with program() as Ramsey_ZZ_coupling:
         q_target = qp.qubit_target
         XY_delay = q_target.xy.opx_output.delay + 4  # Delay to account delayed pulses in the XY channel
         # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qp)
-        if reset_coupler_bias:
-            qp.coupler.set_dc_offset(0.0)
         if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
+            if reset_coupler_bias:
+                qp.coupler.set_dc_offset(0.0)
+        
             wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67b_JAZZ_ZZ_coupling.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67b_JAZZ_ZZ_coupling.py
@@ -156,7 +156,8 @@ with program() as Ramsey_ZZ_coupling:
         q_target = qp.qubit_target
         # Bring the active qubits to the minimum frequency point
         machine.set_all_fluxes(flux_point, qp)
-        wait(1000)
+        if not node.parameters.simulate:
+            wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
             save(n, n_st)
@@ -168,11 +169,12 @@ with program() as Ramsey_ZZ_coupling:
                     
                     assign(t_half, t/2)
                     
-                    if node.parameters.reset_type == "active":
-                        active_reset(qp.qubit_control)
-                        active_reset(qp.qubit_target)
-                    else:
-                        wait(qp.qubit_control.thermalization_time * u.ns)
+                    if not node.parameters.simulate:
+                        if node.parameters.reset_type == "active":
+                            active_reset(qp.qubit_control)
+                            active_reset(qp.qubit_target)
+                        else:
+                            wait(qp.qubit_control.thermalization_time * u.ns)
                     qp.align()
                     
                     # Reset the frames of both qubits
@@ -290,25 +292,25 @@ if not node.parameters.simulate:
             })
             ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
         else:
-            if "flux_coupler_full" not in ds.coords:
-                fluxes_coupler = np.linspace(
-                    -node.parameters.flux_span / 2,
-                    node.parameters.flux_span / 2,
-                    node.parameters.flux_num,
-                )
-                flux_coupler_full = np.array([
-                    fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
-                ])
-                ds = ds.assign_coords({
-                    "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
-                })
-            if "idle_time" not in ds.coords:
-                idle_times = np.arange(
-                    node.parameters.min_wait_time_in_ns // 4,
-                    node.parameters.max_wait_time_in_ns // 4,
-                    node.parameters.wait_time_step_in_ns // 4,
-                )
-                ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
+                if "flux_coupler_full" not in ds.coords:
+                    fluxes_coupler = np.linspace(
+                        -node.parameters.flux_span / 2,
+                        node.parameters.flux_span / 2,
+                        node.parameters.flux_num,
+                    )
+                    flux_coupler_full = np.array([
+                        fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
+                    ])
+                    ds = ds.assign_coords({
+                        "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
+                    })
+                if "idle_time" not in ds.coords:
+                    idle_times = np.arange(
+                        node.parameters.min_wait_time_in_ns // 4,
+                        node.parameters.max_wait_time_in_ns // 4,
+                        node.parameters.wait_time_step_in_ns // 4,
+                    )
+                    ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
 
         fit_curve_list = []
         chiZZ_list = []

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67b_JAZZ_ZZ_coupling.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67b_JAZZ_ZZ_coupling.py
@@ -155,8 +155,8 @@ with program() as Ramsey_ZZ_coupling:
         q_control = qp.qubit_control
         q_target = qp.qubit_target
         # Bring the active qubits to the minimum frequency point
-        machine.set_all_fluxes(flux_point, qp)
         if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
             wait(1000)
 
         with for_(n, 0, n < n_avg, n + 1):
@@ -292,25 +292,25 @@ if not node.parameters.simulate:
             })
             ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
         else:
-                if "flux_coupler_full" not in ds.coords:
-                    fluxes_coupler = np.linspace(
-                        -node.parameters.flux_span / 2,
-                        node.parameters.flux_span / 2,
-                        node.parameters.flux_num,
-                    )
-                    flux_coupler_full = np.array([
-                        fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
-                    ])
-                    ds = ds.assign_coords({
-                        "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
-                    })
-                if "idle_time" not in ds.coords:
-                    idle_times = np.arange(
-                        node.parameters.min_wait_time_in_ns // 4,
-                        node.parameters.max_wait_time_in_ns // 4,
-                        node.parameters.wait_time_step_in_ns // 4,
-                    )
-                    ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
+            if "flux_coupler_full" not in ds.coords:
+                fluxes_coupler = np.linspace(
+                    -node.parameters.flux_span / 2,
+                    node.parameters.flux_span / 2,
+                    node.parameters.flux_num,
+                )
+                flux_coupler_full = np.array([
+                    fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
+                ])
+                ds = ds.assign_coords({
+                    "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
+                })
+            if "idle_time" not in ds.coords:
+                idle_times = np.arange(
+                    node.parameters.min_wait_time_in_ns // 4,
+                    node.parameters.max_wait_time_in_ns // 4,
+                    node.parameters.wait_time_step_in_ns // 4,
+                )
+                ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
 
         fit_curve_list = []
         chiZZ_list = []

--- a/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67bx_JAZZ_ZZ_coupling_v2_state_preparation.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/calibration_graph/67bx_JAZZ_ZZ_coupling_v2_state_preparation.py
@@ -1,0 +1,532 @@
+# %%
+"""
+Two-Qubit ZZ Coupling Measurement (JAZZ, differential control-state readout)
+
+Corrected variant of 67b_JAZZ_ZZ_coupling: sweeps control qubit prepared in |0⟩ and |1⟩,
+then extracts χZZ from the difference of fitted oscillation frequencies divided by 2.
+"""
+
+# %% {Imports}
+from qualibrate import QualibrationNode, NodeParameters
+from quam_libs.components import QuAM
+from quam_libs.macros import active_reset, readout_state, readout_state_gef, active_reset_gef, active_reset_simple
+from quam_libs.lib.plot_utils import QubitPairGrid, grid_iter, grid_pair_names
+from quam_libs.lib.save_utils import (
+    fetch_results_as_xarray,
+    restore_load_data_id,
+    resolve_qubit_pairs_from_node,
+)
+from qualang_tools.results import progress_counter, fetching_tool
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.units import unit
+from qm import SimulationConfig
+from qm.qua import *
+from typing import Literal, Optional, List
+import matplotlib.pyplot as plt
+import numpy as np
+import warnings
+from qualang_tools.bakery import baking
+from quam_libs.lib.fit import fit_oscillation, oscillation, fix_oscillation_phi_2pi
+from quam_libs.lib.plot_utils import QubitPairGrid, grid_iter, grid_pair_names
+from scipy.optimize import curve_fit
+from quam_libs.components.gates.two_qubit_gates import CZGate
+from quam_libs.lib.pulses import FluxPulse
+from quam_libs.lib.fit import fit_oscillation_decay_exp, oscillation_decay_exp
+import xarray as xr
+
+# %% {Node_parameters}
+qubit_pair_indexes = [4]  # The indexes of the qubit pairs to measure
+class Parameters(NodeParameters):
+
+    qubit_pairs: Optional[List[str]] = ["coupler_q%s_q%s"%(i,i+1) for i in qubit_pair_indexes]
+    num_averages: int = 200
+    flux_point_joint_or_independent_or_pairwise: Literal["joint", "independent", "pairwise"] = "joint"
+    reset_type: Literal['active', 'thermal'] = 'active'
+    simulate: bool = False
+    timeout: int = 100
+    load_data_id: Optional[int] = None
+    frequency_detuning_in_mhz: float = 4.0
+    """Frequency detuning in MHz. Default is 1.0 MHz."""
+    min_wait_time_in_ns: int = 16
+    """Minimum wait time in nanoseconds. Default is 16."""
+    max_wait_time_in_ns: int = 816
+    """Maximum wait time in nanoseconds. Default is 5000."""
+    wait_time_step_in_ns: int = 8
+    """Step size for the wait time scan in nanoseconds. Default is 60."""
+    flux_span: float = 0.6
+    """Span of flux values to sweep in volts. Default is 0.01 V."""
+    flux_num: int = 501
+    """Number of flux points to sample. Default is 21."""
+    use_state_discrimination: bool = True
+
+    
+
+node = QualibrationNode(
+    name="67bx_JAZZ_ZZ_coupling_correct", parameters=Parameters()
+)
+assert not (node.parameters.simulate and node.parameters.load_data_id is not None), "If simulate is True, load_data_id must be None, and vice versa."
+
+# %% {Initialize_QuAM_and_QOP}
+# Class containing tools to help handling units and conversions.
+u = unit(coerce_to_integer=True)
+# Instantiate the QuAM class from the state file
+machine = QuAM.load()
+
+# Get the relevant QuAM components
+if node.parameters.qubit_pairs is None or node.parameters.qubit_pairs == "":
+    qubit_pairs = machine.active_qubit_pairs
+else:
+    qubit_pairs = [machine.qubit_pairs[qp] for qp in node.parameters.qubit_pairs]
+
+num_qubit_pairs = len(qubit_pairs)
+
+# Generate the OPX and Octave configurations
+config = machine.generate_config()
+octave_config = machine.get_octave_config()
+# Open Communication with the QOP
+if node.parameters.load_data_id is None:
+    qmm = machine.connect()
+
+
+# %% {QUA_program}
+n_avg = node.parameters.num_averages  # The number of averages
+detuning = int(1e6 * node.parameters.frequency_detuning_in_mhz)
+flux_point = node.parameters.flux_point_joint_or_independent_or_pairwise  # 'independent' or 'joint' or 'pairwise'
+
+# Loop parameters
+fluxes_coupler = np.linspace(
+        -node.parameters.flux_span / 2,
+        node.parameters.flux_span / 2,
+        node.parameters.flux_num,
+    )
+idle_times = np.arange(
+    node.parameters.min_wait_time_in_ns // 4,
+    node.parameters.max_wait_time_in_ns // 4,
+    node.parameters.wait_time_step_in_ns // 4,
+)
+
+with program() as Ramsey_ZZ_coupling:
+    n = declare(int)
+    flux_coupler = declare(float)
+    flux_qubit = declare(float)
+    n_st = declare_stream()
+    control_initial = declare(int)  # initial state of the control qubit
+    t = declare(int)  # QUA variable for the idle time
+    t_half = declare(int)
+    phi = declare(fixed)  # QUA variable for dephasing the second pi/2 pulse (virtual Z-rotation)
+    current_state = [declare(int) for _ in range(num_qubit_pairs)]
+    state_target = [declare(int) for _ in range(num_qubit_pairs)]
+    I_target = [declare(float) for _ in range(num_qubit_pairs)]
+    Q_target = [declare(float) for _ in range(num_qubit_pairs)]
+    state_st_target = [declare_stream() for _ in range(num_qubit_pairs)]
+    I_st_target = [declare_stream() for _ in range(num_qubit_pairs)]
+    Q_st_target = [declare_stream() for _ in range(num_qubit_pairs)]
+    
+    
+    for i, qp in enumerate(qubit_pairs):
+        q_control = qp.qubit_control
+        q_target = qp.qubit_target
+        # Bring the active qubits to the minimum frequency point
+        if not node.parameters.simulate:
+            machine.set_all_fluxes(flux_point, qp)
+            wait(1000)
+
+        with for_(n, 0, n < n_avg, n + 1):
+            save(n, n_st)
+            with for_(*from_array(flux_coupler, fluxes_coupler)):
+                with for_(*from_array(t, idle_times)):
+                    with for_(*from_array(control_initial, [0, 1])):
+                        # Rotate the frame of the second x90 gate to implement a virtual Z-rotation
+                        # 4*tau because tau was in clock cycles and 1e-9 because tau is ns                    
+                        assign(phi, Cast.mul_fixed_by_int(detuning * 1e-9, 4 * t))
+                        
+                        assign(t_half, t/2)
+                        
+                        if not node.parameters.simulate:
+                            if node.parameters.reset_type == "active":
+                                active_reset(qp.qubit_control)
+                                active_reset(qp.qubit_target)
+                            else:
+                                wait(qp.qubit_control.thermalization_time * u.ns)
+                        qp.align()
+                        
+                        # Reset the frames of both qubits
+                        reset_frame(qp.qubit_target.xy.name)
+                        reset_frame(qp.qubit_control.xy.name)
+
+                        # Prepare control qubit in |1⟩ when control_initial == 1
+                        qp.qubit_control.xy.play("x180", condition=control_initial == 1)
+                        qp.align()
+                        
+                        # pi pulse on target qubit
+                        qp.qubit_target.xy.play("x90")
+                        qp.align()
+                        
+                        # Coupler flux pulse
+                        qp.coupler.play(
+                            "const", amplitude_scale=flux_coupler / qp.coupler.operations["const"].amplitude, duration=t_half
+                        )
+                        qp.qubit_target.xy.wait(t_half)
+                        qp.qubit_control.xy.wait(t_half)
+                        
+                        # Echo pulse
+                        qp.qubit_control.xy.play("x180")
+                        qp.qubit_target.xy.play("x180")
+                        qp.coupler.wait(qp.qubit_target.xy.operations["x180"].length//4)
+                        
+                        # Coupler flux pulse
+                        qp.coupler.play(
+                            "const", amplitude_scale=flux_coupler / qp.coupler.operations["const"].amplitude, duration=t_half
+                        )
+                        qp.qubit_target.xy.wait(t_half)
+                        qp.qubit_control.xy.wait(t_half)
+                        
+                        # rotate the frame
+                        qp.qubit_target.xy.frame_rotation_2pi(phi)
+                        # Tomographic rotation on the target qubit
+                        qp.qubit_target.xy.play("x90")
+                        qp.align() 
+                        
+                        # target qubit readout
+                        if node.parameters.use_state_discrimination:
+                            readout_state(q_target, current_state[i])
+                            save(current_state[i], state_st_target[i])
+                            reset_frame(q_target.xy.name)
+                        else:
+                            q_target.resonator.measure("readout", qua_vars=(I_target[i], Q_target[i]))
+                            save(I_target[i], I_st_target[i])
+                            save(Q_target[i], Q_st_target[i])
+                        align()
+        
+    with stream_processing():
+        n_st.save("n")
+        for i in range(num_qubit_pairs):
+            if node.parameters.use_state_discrimination:
+                state_st_target[i].buffer(2).buffer(len(idle_times)).buffer(len(fluxes_coupler)).average().save(f"state_target{i + 1}")
+            else:
+                I_st_target[i].buffer(2).buffer(len(idle_times)).buffer(len(fluxes_coupler)).average().save(f"I_target{i + 1}")
+                Q_st_target[i].buffer(2).buffer(len(idle_times)).buffer(len(fluxes_coupler)).average().save(f"Q_target{i + 1}")
+
+# %% {Simulate_or_execute}
+if node.parameters.simulate:
+    # Simulates the QUA program for the specified duration
+    simulation_config = SimulationConfig(duration=10_000 //4)  # In clock cycles = 4ns
+    job = qmm.simulate(config, Ramsey_ZZ_coupling, simulation_config)
+    samples = job.get_simulated_samples()
+    samples.con1.plot()
+    node.results = {"figure": plt.gcf()}
+    wf_report = job.get_simulated_waveform_report()
+    wf_report.create_plot(samples, plot=True, save_path=None)
+    node.machine = machine
+    node.save()
+elif node.parameters.load_data_id is None:
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        job = qm.execute(Ramsey_ZZ_coupling)
+
+        results = fetching_tool(job, ["n"], mode="live")
+        while results.is_processing():
+            # Fetch results
+            n = results.fetch_all()[0]
+            # Progress bar
+            progress_counter(n, n_avg, start_time=results.start_time)
+
+# %% {Data_fetching_and_dataset_creation}
+if not node.parameters.simulate:
+    if node.parameters.load_data_id is None:
+        # Fetch the data from the OPX and convert it into a xarray with corresponding axes (from most inner to outer loop)
+        ds = fetch_results_as_xarray(
+            job.result_handles,
+            qubit_pairs,
+            {"control_state": [0, 1], "idle_time": idle_times, "flux_coupler": fluxes_coupler},
+        )
+    else:
+        load_data_id = node.parameters.load_data_id
+        node = node.load_from_id(load_data_id)
+        ds = node.results["ds"]
+        restore_load_data_id(node, load_data_id)
+        machine = node.machine
+        qubit_pairs = resolve_qubit_pairs_from_node(machine, node)
+# %% {Data_analysis}
+node.results = {"ds": ds}
+node.results["fit_results"] = {}
+node.results["analysis_success"] = {}
+
+if not node.parameters.simulate:
+    try:
+        print("Starting analysis...")
+        target_signal_name = "state_target" if "state_target" in ds.data_vars else "I_target"
+        print(f"Using '{target_signal_name}' for ZZ analysis.")
+
+        if node.parameters.load_data_id is None:
+            flux_coupler_full = np.array([
+                fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
+            ])
+            ds = ds.assign_coords({
+                "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
+            })
+            ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
+        else:
+            if "flux_coupler_full" not in ds.coords:
+                fluxes_coupler = np.linspace(
+                    -node.parameters.flux_span / 2,
+                    node.parameters.flux_span / 2,
+                    node.parameters.flux_num,
+                )
+                flux_coupler_full = np.array([
+                    fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs
+                ])
+                ds = ds.assign_coords({
+                    "flux_coupler_full": (["qubit", "flux_coupler"], flux_coupler_full)
+                })
+            if "idle_time" not in ds.coords:
+                idle_times = np.arange(
+                    node.parameters.min_wait_time_in_ns // 4,
+                    node.parameters.max_wait_time_in_ns // 4,
+                    node.parameters.wait_time_step_in_ns // 4,
+                )
+                ds = ds.assign_coords(idle_time=4 * idle_times / 1e3)
+
+        fit_curve_list = []
+        chiZZ_list = []
+        chiZZ_std_list = []
+
+        for i, qp in enumerate(qubit_pairs):
+            print(f"Analyzing qubit pair {i}: {qp.id if hasattr(qp, 'id') else qp}")
+            target_signal_pair = ds[target_signal_name].sel(qubit=qp.name)
+
+            fit_data = fit_oscillation_decay_exp(target_signal_pair, "idle_time")
+
+            fit_ok = (
+                np.isfinite(fit_data.sel(fit_vals="f")).any()
+                and not np.isnan(fit_data.sel(fit_vals="f")).all()
+            )
+
+            fitted_pair = oscillation_decay_exp(
+                target_signal_pair.idle_time,
+                fit_data.sel(fit_vals="a"),
+                fit_data.sel(fit_vals="f"),
+                fit_data.sel(fit_vals="phi"),
+                fit_data.sel(fit_vals="offset"),
+                fit_data.sel(fit_vals="decay"),
+            )
+            fit_curve_list.append(fitted_pair.expand_dims(qubit=[qp.name]))
+
+            f0 = fit_data.sel(fit_vals="f", control_state=0)
+            f1 = fit_data.sel(fit_vals="f", control_state=1)
+            chiZZ_pair = (f1 - f0) * 1e3  # MHz → kHz, differential χZZ
+            chiZZ_list.append(chiZZ_pair.expand_dims(qubit=[qp.name]))
+
+            chiZZ_std_pair = 1e3 / 2 * np.sqrt(
+                fit_data.sel(fit_vals="f_f", control_state=0)
+                + fit_data.sel(fit_vals="f_f", control_state=1)
+            )
+            chiZZ_std_list.append(chiZZ_std_pair.expand_dims(qubit=[qp.name]))
+
+            chiZZ_std_filt = chiZZ_std_pair.where(chiZZ_std_pair < chiZZ_std_pair.median() * 2)
+            chiZZ_filt = chiZZ_pair.where(~np.isnan(chiZZ_std_filt))
+
+            max_idx = abs(chiZZ_filt).argmax(dim="flux_coupler").item()
+            min_idx = abs(chiZZ_filt).argmin(dim="flux_coupler").item()
+
+            flux_full = ds["flux_coupler_full"].sel(qubit=qp.name)
+            flux_val_max = float(flux_full.isel(flux_coupler=max_idx))
+            flux_val_min = float(flux_full.isel(flux_coupler=min_idx))
+            chi_max = float(chiZZ_pair.isel(flux_coupler=max_idx))
+            chi_min = float(chiZZ_pair.isel(flux_coupler=min_idx))
+
+            node.results["fit_results"][qp.name] = {
+                "chiZZ_max_flux": flux_val_max,
+                "chiZZ_min_flux": flux_val_min,
+                "chiZZ_max_value": chi_max,
+                "chiZZ_min_value": chi_min,
+            }
+            node.results["analysis_success"][qp.name] = "successful" if fit_ok else "failed"
+
+            print(f"  → max |χZZ|={chi_max:.2f} kHz @ {flux_val_max:.3f}")
+            print(f"  → χZZ≈0={chi_min:.2f} kHz @ {flux_val_min:.3f}")
+            print(f"  → fit status: {'success' if fit_ok else 'failed'}")
+
+        ds["target_signal_fit"] = xr.concat(fit_curve_list, dim="qubit")
+        ds["chiZZ"] = xr.concat(chiZZ_list, dim="qubit")
+        ds["chiZZ_std"] = xr.concat(chiZZ_std_list, dim="qubit")
+        node.results["ds"] = ds
+        print("Analysis complete ")
+
+    except Exception as e:
+        node.results["analysis_error"] = str(e)
+        node.results["ds"] = ds
+        print(f"Analysis failed : {e}")
+
+# %% {plotting}
+
+if not node.parameters.simulate:
+    for i, qp in enumerate(qubit_pairs):
+        qubit_name = qp.name
+        fit_status = node.results.get("analysis_success", {}).get(qubit_name, "failed")
+
+        # =====================================================
+        # --- Always plot raw Ramsey / state_target heatmaps ---
+        # =====================================================
+        print(f"Plotting raw data for {qubit_name}")
+        ds_pair = ds.isel(qubit=i)
+        flux_full = ds_pair["flux_coupler_full"]
+        flux_mV = 1e3 * flux_full.squeeze()
+        idle_time_us = ds_pair["idle_time"]
+        target_signal_name = "state_target" if "state_target" in ds_pair.data_vars else "I_target"
+        raw_data_label = "State probability" if target_signal_name == "state_target" else "I quadrature [a.u.]"
+
+        for ctrl in [0, 1]:
+            fig, ax = plt.subplots(figsize=(6, 4))
+            data = ds_pair[target_signal_name].sel(control_state=ctrl)
+            im = ax.pcolormesh(
+                flux_mV,
+                idle_time_us,
+                data.transpose(),
+                shading="auto",
+                cmap="viridis",
+                vmin=0 if target_signal_name == "state_target" else None,
+                vmax=1 if target_signal_name == "state_target" else None,
+            )
+            fig.colorbar(im, ax=ax, label=raw_data_label)
+            ax.set_xlabel("Coupler flux [mV]")
+            ax.set_ylabel("Idle time [µs]")
+            ax.set_title(f"{qubit_name} – Raw JAZZ (control={ctrl})", fontsize=10)
+            plt.tight_layout()
+            node.results[f"figure_raw_{qubit_name}_ctrl{ctrl}"] = fig
+            plt.show()
+
+        if fit_status == "successful" and "chiZZ" in ds:
+            print(f"Plotting χZZ analysis for {qubit_name}")
+            ds_pair = ds.isel(qubit=i)
+            chi = ds_pair["chiZZ"]
+            chi_std = ds_pair["chiZZ_std"]
+            flux_full = ds_pair["flux_coupler_full"]
+            flux_mV = 1e3 * flux_full.squeeze()
+
+            res = node.results["fit_results"][qubit_name]
+            flux_val_max = res["chiZZ_max_flux"]
+            flux_val_min = res["chiZZ_min_flux"]
+            chi_max = res["chiZZ_max_value"]
+            chi_min = res["chiZZ_min_value"]
+
+            # --- χZZ vs flux plot ---
+            # --- χZZ vs flux: 2 subplots (linear + log-log) ---
+            fig, axes = plt.subplots(1, 2, figsize=(12, 6), sharex=False)
+
+            # Common data
+            chi_val = chi.squeeze()
+            chi_std_val = chi_std.squeeze()
+            chi_abs = np.abs(chi_val)
+
+            # ---------------- (1) Linear plot ----------------
+            ax = axes[0]
+            ax.errorbar(
+                flux_mV,
+                chi_val,
+                yerr=chi_std_val,
+                fmt="-o",
+                color="tab:red",
+                lw=1.8,
+                elinewidth=1,
+                capsize=3,
+                markersize=4,
+                alpha=0.9,
+                label="χZZ ± fit std",
+            )
+            ax.axvline(1e3 * flux_val_max, color="k", linestyle="--", lw=1.2, alpha=0.8, label="max |χZZ|")
+            ax.axvline(1e3 * flux_val_min, color="gray", linestyle="--", lw=1.2, alpha=0.6, label="min |χZZ|")
+            ax.axhline(0, color="k", lw=1, alpha=0.4)
+            ax.set_title("Linear scale")
+            ax.set_xlabel("Coupler flux [mV]")
+            ax.set_ylabel("χZZ [kHz]")
+            ax.grid(True)
+            ax.legend(fontsize=8)
+
+            # ---------------- (2) Log-log plot ----------------
+            ax = axes[1]   # axes[1]
+            ax.errorbar(
+                flux_mV,     # must be positive for log
+                chi_abs,
+                yerr=chi_std_val,
+                fmt="-o",
+                color="tab:blue",
+                lw=1.8,
+                elinewidth=1,
+                capsize=3,
+                markersize=4,
+                alpha=0.9,
+                label="|χZZ| ± std",
+            )
+            ax.set_yscale("log")
+            ax.set_title("Log-log scale")
+            ax.set_xlabel("|Coupler flux| [mV]")
+            ax.set_ylabel("|χZZ| [kHz]")
+            ax.grid(True, which="both", ls="--", alpha=0.5)
+            ax.legend(fontsize=8)
+
+            coupler_offset_mV = 1e3 * qp.coupler.decouple_offset
+            fig.suptitle(
+                f"{qubit_name}: χZZ vs Coupler Flux (Current coupler offset = {coupler_offset_mV:.3f} mV)",
+                fontsize=12,
+            )
+
+            plt.tight_layout(rect=[0, 0, 1, 0.95])
+            node.results[f"figure_zz_curve_{qubit_name}"] = fig
+            plt.show()
+
+
+            # --- Time-domain fits at χZZ max and min ---
+            for label, flux_val, chi_val in [
+                ("max", flux_val_max, chi_max),
+                ("min", flux_val_min, chi_min),
+            ]:
+                flux_idx = int((abs(flux_full - flux_val)).argmin(dim="flux_coupler").item())
+                idle_time = ds_pair["idle_time"]
+
+                for ctrl in [0, 1]:
+                    meas = ds_pair[target_signal_name].isel(flux_coupler=flux_idx).sel(control_state=ctrl)
+                    fit = ds_pair["target_signal_fit"].isel(flux_coupler=flux_idx).sel(control_state=ctrl)
+
+                    fig, axes = plt.subplots(1, 2, figsize=(8, 4), sharex=True)
+                    axes[0].plot(
+                        idle_time,
+                        meas,
+                        "-",
+                        alpha=0.8,
+                    )
+                    axes[1].plot(
+                        idle_time,
+                        fit,
+                        "-",
+                        lw=2,
+                    )
+                    axes[0].set_title(f"Measured ({qubit_name}, ctrl={ctrl})")
+                    axes[1].set_title("Fitted")
+                    for ax_ in axes:
+                        ax_.set_xlabel("Idle time [µs]")
+                        ax_.set_ylabel("State")
+                    fig.suptitle(
+                        f"{qubit_name} ({label} |χZZ|), ctrl={ctrl}: Flux={flux_val:.3f}, χZZ={chi_val:.2f} kHz",
+                        fontsize=12,
+                    )
+                    plt.tight_layout(rect=[0, 0, 1, 0.96])
+                    node.results[f"figure_fit_{label}_chiZZ_{qubit_name}_ctrl{ctrl}"] = fig
+                    plt.show()
+
+        else:
+            print(f"No χZZ analysis or failed fit for {qubit_name} — only raw data plotted.")
+
+#%% {Update state}
+if node.parameters.load_data_id is None:
+        with node.record_state_updates():
+            for i, qp in enumerate(qubit_pairs):
+                qp.extras["ZZ_zero_flux"] = node.results['fit_results'][qp.name]["chiZZ_min_flux"]
+                qp.coupler.decouple_offset = node.results['fit_results'][qp.name]["chiZZ_min_flux"]
+#  %% {Save_results}
+if not node.parameters.simulate:
+    node.outcomes = {q.name: "successful" for q in qubit_pairs}
+    node.results['initial_parameters'] = node.parameters.model_dump()
+    node.machine = machine
+    node.save()
+# %%

--- a/Quantum-Control-Applications-QuAM/Superconducting/configuration/reset_pi_pulse_parameter.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/configuration/reset_pi_pulse_parameter.py
@@ -1,0 +1,21 @@
+"""
+Reset x180 / x90 pulse parameters for all active qubits in the current state.json:
+  alpha = -1.0, detuning = 0.0
+"""
+from quam_libs.components import QuAM
+
+machine = QuAM.load()
+qubits = machine.active_qubits
+
+for q in qubits:
+    for op in ("x180", "x90"):
+        pulse = q.xy.operations[op]
+        print(
+            f"{q.name} {op}: alpha {pulse.alpha} -> -1.0, "
+            f"detuning {getattr(pulse, 'detuning', None)} -> 0.0"
+        )
+        pulse.alpha = -1.0
+        pulse.detuning = 0.0
+
+machine.save()
+print(f"Saved state with updated x180/x90 for {len(qubits)} active qubit(s).")

--- a/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/lib/instrument_limits.py
+++ b/Quantum-Control-Applications-QuAM/Superconducting/quam_libs/lib/instrument_limits.py
@@ -26,7 +26,7 @@ def instrument_limits(channel: Union[IQChannel, MWChannel]) -> InstrumentLimits:
     if isinstance(channel, MWChannel):
         limits = InstrumentLimits(
             max_wf_amplitude=1,  # MW-FEM max normalized amplitude
-            max_x180_wf_amplitude=0.6,  # A subjective "safe" value for x180 pulses
+            max_x180_wf_amplitude=1.0,  # A subjective "safe" value for x180 pulses
             units="(scaled by `full_scale_power_dbm`)"
         )
     elif isinstance(channel, IQChannel):


### PR DESCRIPTION
Merge `qm_develop` into `main`, integrating recent calibration node improvements. This PR incorporates the core changes originally proposed in [PR #7](https://github.com/asqum/qua-libs/pull/7), consolidated and refined on `qm_develop`.

## Key Changes

### 1. Simulation mode improvements
- When `simulate=True`, skip qubit flux setup, coupler positioning, and active reset / thermalization pulses
- Enables faster simulation without preparation steps

### 2. `03b_qubit_spectroscopy_vs_flux.py`: persist flux fit results in extras
- After fitting, store `sweetspot_freq`, `sweet_offset`, and `flux_phase_ratio` in each qubit’s `extras`

### 3. `09_Power_Rabi_State.py`: update x90 while calibrating x180
- After x180 Power Rabi fitting, automatically set `x90.amplitude = Pi_amplitude / 2` if `update_x90` is `True`.

### 4. Add `67bx_JAZZ_ZZ_coupling_v2_state_preparation.py`: 
- Adds control-qubit state preparation (|0⟩ and |1⟩) before the JAZZ sequence
- Still under testing; it has not yet been decided whether to deprecate 67b in favor of 67bx.

### 5. Add `100a_Gate_Set_Tomography_AIS.py`: 
- Streams germ sequences to the OPX via `advance_input_stream`

### 6. Add `configuration/reset_pi_pulse_parameter.py`: 
- Resets `x180` and `x90` pulse parameters for all active qubits to `alpha = -1.0`, `detuning = 0.0`
- equivalent to the `06r` concept in PR #7


## Relationship to PR #7

This PR integrates the four main items from [PR #7 (20260702 update)](https://github.com/asqum/qua-libs/pull/7):

1. ✅ 03b: store flux fit parameters in extras
2. ✅ 09: update x90 while running x180
3. ✅ 67bx as corrected version of 67b (replacement TBD)
4. ✅ DRAG / detuning reset utility (`reset_pi_pulse_parameter.py`)